### PR TITLE
BGP negotiated timers. Display BGP timers in CLI.

### DIFF
--- a/bgpd/bgp_ovsdb_if.c
+++ b/bgpd/bgp_ovsdb_if.c
@@ -342,6 +342,7 @@ bgp_ovsdb_tables_init (struct ovsdb_idl *idl)
     ovsdb_idl_add_column(idl, &ovsrec_bgp_neighbor_col_passive);
     ovsdb_idl_add_column(idl, &ovsrec_bgp_neighbor_col_password);
     ovsdb_idl_add_column(idl, &ovsrec_bgp_neighbor_col_timers);
+    ovsdb_idl_add_column(idl, &ovsrec_bgp_neighbor_col_negotiated_timers);
     ovsdb_idl_add_column(idl, &ovsrec_bgp_neighbor_col_route_maps);
     ovsdb_idl_add_column(idl, &ovsrec_bgp_neighbor_col_prefix_lists);
     ovsdb_idl_add_column(idl, &ovsrec_bgp_neighbor_col_aspath_filters);
@@ -2085,6 +2086,8 @@ void bgp_daemon_ovsdb_neighbor_update (struct peer *peer,
     struct ovsdb_idl_txn *db_txn;
     enum ovsdb_idl_txn_status status;
     struct smap smap;
+    int64_t value_timers[2];
+    char *key_timers[2];
 
     ovs_bgp_neighbor_ptr = get_bgp_neighbor_db_row(peer);
     if (NULL == ovs_bgp_neighbor_ptr) {
@@ -2122,10 +2125,6 @@ void bgp_daemon_ovsdb_neighbor_update (struct peer *peer,
         &peer->local_as, 1);
      */
 
-    VLOG_DBG("updating weight to %d\n", peer->weight);
-    ovsrec_bgp_neighbor_set_weight(ovs_bgp_neighbor_ptr,
-        (int64_t*) &peer->weight, 1);
-
     smap_init(&smap);
     smap_add(&smap, BGP_PEER_STATE, bgp_peer_status_to_string(peer->status));
     VLOG_DBG("updating bgp neighbor status to %s\n",
@@ -2138,6 +2137,16 @@ void bgp_daemon_ovsdb_neighbor_update (struct peer *peer,
 	    ovs_bgp_neighbor_ptr, peer);
 	VLOG_DBG("updated stats also\n");
     }
+
+    /* Update per-neighbor negotiated timers */
+    key_timers[0] = OVSDB_BGP_TIMER_KEEPALIVE;
+    key_timers[1] = OVSDB_BGP_TIMER_HOLDTIME;
+    value_timers[0] = (int64_t)peer->v_keepalive;
+    value_timers[1] = (int64_t)peer->v_holdtime;
+    VLOG_DBG("Updating BGP neighbor timers keepalive to %ld, holdtime to %ld",
+        value_timers[0], value_timers[1]);
+    ovsrec_bgp_neighbor_set_negotiated_timers(ovs_bgp_neighbor_ptr,
+        key_timers, value_timers, 2);
 
     status = ovsdb_idl_txn_commit(db_txn);
     VLOG_DBG("%s OVSDB Neighbour update status is %s", __FUNCTION__,


### PR DESCRIPTION
Tags: fix, dev, Github issue #13

Change-Id: I0f2d5fa682457205f41937f1848a1ff51d21535a
Signed-off-by: Ilya Schepin ischepin@mera.ru

CLI command `show ip bgp neighbors` will now show per-neighbor (or per-peer-group) configured BGP timers (keepalive and holdtime) and per-neighbor negotiated timers.  
New status field `negotiated_timers` was added to OVSDB table BGP_Neighbor  
Priority of timer parameters as follows:  
Per-peer-group configured > per-neighbor configured > per-router configured > default values  
Depends on MERAprojects/ops#3 and MERAprojects/ops-cli#10
