### PR TITLE
Automatic OSPF router-id assignment.

### DIFF
--- a/bgpd/bgp_backend_functions.h
+++ b/bgpd/bgp_backend_functions.h
@@ -69,5 +69,23 @@ extern int daemon_bgp_clear_request (const char *name, afi_t afi, safi_t safi,
                             const char *arg);
 extern int daemon_neighbor_peer_group_cmd_execute (struct bgp *bgp, const char *groupName);
 
+#define BFD_SESSION_STATE_ADMIN_DOWN   0 // must match ovsrec_bfd_session_state
+#define BFD_SESSION_STATE_DOWN         1 // must match ovsrec_bfd_session_state
+#define BFD_SESSION_STATE_INIT         2 // must match ovsrec_bfd_session_state
+#define BFD_SESSION_STATE_UP           3 // must match ovsrec_bfd_session_state
+
+#define BFD_SESSION_STATE_STR_ADMIN_DOWN "admin_down"
+#define BFD_SESSION_STATE_STR_DOWN       "down"
+#define BFD_SESSION_STATE_STR_INIT       "init"
+#define BFD_SESSION_STATE_STR_UP         "up"
+
+extern int daemon_neighbor_bfd_fallover_enable_cmd_execute (struct bgp *bgp, char *peer_str, bool fall_over);
+
+extern int daemon_neighbor_bfd_state_cmd_execute (struct bgp *bgp, char *peer_str, int bfd_state);
+
+extern int bgp_bfd_neigh_add(struct peer *peer);
+extern int bgp_bfd_neigh_del(struct peer *peer);
+extern int bgp_bfd_neigh_estab(struct peer *peer);
+
 
 #endif /* BGP_BACKEND_FUNCTIONS_H */

--- a/bgpd/bgp_fsm.c
+++ b/bgpd/bgp_fsm.c
@@ -86,18 +86,18 @@ bgp_timer_set (struct peer *peer)
     {
     case Idle:
       /* First entry point of peer's finite state machine.  In Idle
-	 status start timer is on unless peer is shutdown or peer is
-	 inactive.  All other timer must be turned off */
+     status start timer is on unless peer is shutdown or peer is
+     inactive.  All other timer must be turned off */
       if (BGP_PEER_START_SUPPRESSED (peer) || ! peer_active (peer))
-	{
-	  BGP_TIMER_OFF (peer->t_start);
-	}
+    {
+      BGP_TIMER_OFF (peer->t_start);
+    }
       else
-	{
-	  jitter = bgp_start_jitter (peer->v_start);
-	  BGP_TIMER_ON (peer->t_start, bgp_start_timer,
-			peer->v_start + jitter);
-	}
+    {
+      jitter = bgp_start_jitter (peer->v_start);
+      BGP_TIMER_ON (peer->t_start, bgp_start_timer,
+            peer->v_start + jitter);
+    }
       BGP_TIMER_OFF (peer->t_connect);
       BGP_TIMER_OFF (peer->t_holdtime);
       BGP_TIMER_OFF (peer->t_keepalive);
@@ -123,14 +123,14 @@ bgp_timer_set (struct peer *peer)
       BGP_TIMER_OFF (peer->t_start);
       /* If peer is passive mode, do not set connect timer. */
       if (CHECK_FLAG (peer->flags, PEER_FLAG_PASSIVE)
-	  || CHECK_FLAG (peer->sflags, PEER_STATUS_NSF_WAIT))
-	{
-	  BGP_TIMER_OFF (peer->t_connect);
-	}
+      || CHECK_FLAG (peer->sflags, PEER_STATUS_NSF_WAIT))
+    {
+      BGP_TIMER_OFF (peer->t_connect);
+    }
       else
-	{
-	  BGP_TIMER_ON (peer->t_connect, bgp_connect_timer, peer->v_connect);
-	}
+    {
+      BGP_TIMER_ON (peer->t_connect, bgp_connect_timer, peer->v_connect);
+    }
       BGP_TIMER_OFF (peer->t_holdtime);
       BGP_TIMER_OFF (peer->t_keepalive);
       BGP_TIMER_OFF (peer->t_asorig);
@@ -142,14 +142,14 @@ bgp_timer_set (struct peer *peer)
       BGP_TIMER_OFF (peer->t_start);
       BGP_TIMER_OFF (peer->t_connect);
       if (peer->v_holdtime != 0)
-	{
-	  BGP_TIMER_ON (peer->t_holdtime, bgp_holdtime_timer, 
-			peer->v_holdtime);
-	}
+    {
+      BGP_TIMER_ON (peer->t_holdtime, bgp_holdtime_timer,
+            peer->v_holdtime);
+    }
       else
-	{
-	  BGP_TIMER_OFF (peer->t_holdtime);
-	}
+    {
+      BGP_TIMER_OFF (peer->t_holdtime);
+    }
       BGP_TIMER_OFF (peer->t_keepalive);
       BGP_TIMER_OFF (peer->t_asorig);
       BGP_TIMER_OFF (peer->t_routeadv);
@@ -163,17 +163,17 @@ bgp_timer_set (struct peer *peer)
       /* If the negotiated Hold Time value is zero, then the Hold Time
          timer and KeepAlive timers are not started. */
       if (peer->v_holdtime == 0)
-	{
-	  BGP_TIMER_OFF (peer->t_holdtime);
-	  BGP_TIMER_OFF (peer->t_keepalive);
-	}
+    {
+      BGP_TIMER_OFF (peer->t_holdtime);
+      BGP_TIMER_OFF (peer->t_keepalive);
+    }
       else
-	{
-	  BGP_TIMER_ON (peer->t_holdtime, bgp_holdtime_timer,
-			peer->v_holdtime);
-	  BGP_TIMER_ON (peer->t_keepalive, bgp_keepalive_timer, 
-			peer->v_keepalive);
-	}
+    {
+      BGP_TIMER_ON (peer->t_holdtime, bgp_holdtime_timer,
+            peer->v_holdtime);
+      BGP_TIMER_ON (peer->t_keepalive, bgp_keepalive_timer,
+            peer->v_keepalive);
+    }
       BGP_TIMER_OFF (peer->t_asorig);
       BGP_TIMER_OFF (peer->t_routeadv);
       break;
@@ -187,17 +187,17 @@ bgp_timer_set (struct peer *peer)
       /* Same as OpenConfirm, if holdtime is zero then both holdtime
          and keepalive must be turned off. */
       if (peer->v_holdtime == 0)
-	{
-	  BGP_TIMER_OFF (peer->t_holdtime);
-	  BGP_TIMER_OFF (peer->t_keepalive);
-	}
+    {
+      BGP_TIMER_OFF (peer->t_holdtime);
+      BGP_TIMER_OFF (peer->t_keepalive);
+    }
       else
-	{
-	  BGP_TIMER_ON (peer->t_holdtime, bgp_holdtime_timer,
-			peer->v_holdtime);
-	  BGP_TIMER_ON (peer->t_keepalive, bgp_keepalive_timer,
-			peer->v_keepalive);
-	}
+    {
+      BGP_TIMER_ON (peer->t_holdtime, bgp_holdtime_timer,
+            peer->v_holdtime);
+      BGP_TIMER_ON (peer->t_keepalive, bgp_keepalive_timer,
+            peer->v_keepalive);
+    }
       BGP_TIMER_OFF (peer->t_asorig);
       break;
     case Deleted:
@@ -226,7 +226,7 @@ bgp_start_timer (struct thread *thread)
 
   if (BGP_DEBUG (fsm, FSM))
     zlog (peer->log, LOG_DEBUG,
-	  "%s [FSM] Timer (start timer expire).", peer->host);
+      "%s [FSM] Timer (start timer expire).", peer->host);
 
   THREAD_VAL (thread) = BGP_Start;
   bgp_event (thread);  /* bgp_event unlocks peer */
@@ -245,7 +245,7 @@ bgp_connect_timer (struct thread *thread)
 
   if (BGP_DEBUG (fsm, FSM))
     zlog (peer->log, LOG_DEBUG, "%s [FSM] Timer (connect timer expire)",
-	  peer->host);
+      peer->host);
 
   THREAD_VAL (thread) = ConnectRetry_timer_expired;
   bgp_event (thread); /* bgp_event unlocks peer */
@@ -264,8 +264,8 @@ bgp_holdtime_timer (struct thread *thread)
 
   if (BGP_DEBUG (fsm, FSM))
     zlog (peer->log, LOG_DEBUG,
-	  "%s [FSM] Timer (holdtime timer expire)",
-	  peer->host);
+      "%s [FSM] Timer (holdtime timer expire)",
+      peer->host);
 
   THREAD_VAL (thread) = Hold_Timer_expired;
   bgp_event (thread); /* bgp_event unlocks peer */
@@ -284,8 +284,8 @@ bgp_keepalive_timer (struct thread *thread)
 
   if (BGP_DEBUG (fsm, FSM))
     zlog (peer->log, LOG_DEBUG,
-	  "%s [FSM] Timer (keepalive timer expire)",
-	  peer->host);
+      "%s [FSM] Timer (keepalive timer expire)",
+      peer->host);
 
   THREAD_VAL (thread) = KeepAlive_timer_expired;
   bgp_event (thread); /* bgp_event unlocks peer */
@@ -303,15 +303,15 @@ bgp_routeadv_timer (struct thread *thread)
 
   if (BGP_DEBUG (fsm, FSM))
     zlog (peer->log, LOG_DEBUG,
-	  "%s [FSM] Timer (routeadv timer expire)",
-	  peer->host);
+      "%s [FSM] Timer (routeadv timer expire)",
+      peer->host);
 
   peer->synctime = bgp_clock ();
 
   BGP_WRITE_ON (peer->t_write, bgp_write, peer->fd);
 
   BGP_TIMER_ON (peer->t_routeadv, bgp_routeadv_timer,
-		peer->v_routeadv);
+        peer->v_routeadv);
 
   return 0;
 }
@@ -359,7 +359,7 @@ bgp_graceful_restart_timer_expire (struct thread *thread)
   for (afi = AFI_IP ; afi < AFI_MAX ; afi++)
     for (safi = SAFI_UNICAST ; safi < SAFI_RESERVED_3 ; safi++)
       if (peer->nsf[afi][safi])
-	bgp_clear_stale_route (peer, afi, safi);
+    bgp_clear_stale_route (peer, afi, safi);
 
   UNSET_FLAG (peer->sflags, PEER_STATUS_NSF_WAIT);
   BGP_TIMER_OFF (peer->t_gr_stale);
@@ -392,7 +392,7 @@ bgp_graceful_stale_timer_expire (struct thread *thread)
   for (afi = AFI_IP ; afi < AFI_MAX ; afi++)
     for (safi = SAFI_UNICAST ; safi < SAFI_RESERVED_3 ; safi++)
       if (peer->nsf[afi][safi])
-	bgp_clear_stale_route (peer, afi, safi);
+    bgp_clear_stale_route (peer, afi, safi);
 
   return 0;
 }
@@ -416,9 +416,9 @@ bgp_fsm_change_status (struct peer *peer, int status)
   
   if (BGP_DEBUG (normal, NORMAL))
     zlog_debug ("%s went from %s to %s",
-		peer->host,
-		LOOKUP (bgp_status_msg, peer->ostatus),
-		LOOKUP (bgp_status_msg, peer->status));
+        peer->host,
+        LOOKUP (bgp_status_msg, peer->ostatus),
+        LOOKUP (bgp_status_msg, peer->status));
 
 #ifdef ENABLE_OVSDB
   bgp_daemon_ovsdb_neighbor_update(peer, false);
@@ -458,38 +458,38 @@ bgp_stop (struct peer *peer)
 
       /* bgp log-neighbor-changes of neighbor Down */
       if (bgp_flag_check (peer->bgp, BGP_FLAG_LOG_NEIGHBOR_CHANGES))
-	zlog_info ("%%ADJCHANGE: neighbor %s Down %s", peer->host,
+    zlog_info ("%%ADJCHANGE: neighbor %s Down %s", peer->host,
                    peer_down_str [(int) peer->last_reset]);
 
       /* graceful restart */
       if (peer->t_gr_stale)
-	{
-	  BGP_TIMER_OFF (peer->t_gr_stale);
-	  if (BGP_DEBUG (events, EVENTS))
-	    zlog_debug ("%s graceful restart stalepath timer stopped", peer->host);
-	}
+    {
+      BGP_TIMER_OFF (peer->t_gr_stale);
+      if (BGP_DEBUG (events, EVENTS))
+        zlog_debug ("%s graceful restart stalepath timer stopped", peer->host);
+    }
       if (CHECK_FLAG (peer->sflags, PEER_STATUS_NSF_WAIT))
-	{
-	  if (BGP_DEBUG (events, EVENTS))
-	    {
-	      zlog_debug ("%s graceful restart timer started for %d sec",
-			  peer->host, peer->v_gr_restart);
-	      zlog_debug ("%s graceful restart stalepath timer started for %d sec",
-			  peer->host, peer->bgp->stalepath_time);
-	    }
-	  BGP_TIMER_ON (peer->t_gr_restart, bgp_graceful_restart_timer_expire,
-			peer->v_gr_restart);
-	  BGP_TIMER_ON (peer->t_gr_stale, bgp_graceful_stale_timer_expire,
-			peer->bgp->stalepath_time);
-	}
+    {
+      if (BGP_DEBUG (events, EVENTS))
+        {
+          zlog_debug ("%s graceful restart timer started for %d sec",
+              peer->host, peer->v_gr_restart);
+          zlog_debug ("%s graceful restart stalepath timer started for %d sec",
+              peer->host, peer->bgp->stalepath_time);
+        }
+      BGP_TIMER_ON (peer->t_gr_restart, bgp_graceful_restart_timer_expire,
+            peer->v_gr_restart);
+      BGP_TIMER_ON (peer->t_gr_stale, bgp_graceful_stale_timer_expire,
+            peer->bgp->stalepath_time);
+    }
       else
-	{
-	  UNSET_FLAG (peer->sflags, PEER_STATUS_NSF_MODE);
+    {
+      UNSET_FLAG (peer->sflags, PEER_STATUS_NSF_MODE);
 
-	  for (afi = AFI_IP ; afi < AFI_MAX ; afi++)
-	    for (safi = SAFI_UNICAST ; safi < SAFI_RESERVED_3 ; safi++)
-	      peer->nsf[afi][safi] = 0;
-	}
+      for (afi = AFI_IP ; afi < AFI_MAX ; afi++)
+        for (safi = SAFI_UNICAST ; safi < SAFI_RESERVED_3 ; safi++)
+          peer->nsf[afi][safi] = 0;
+    }
 
       /* set last reset time */
       peer->resettime = peer->uptime = bgp_clock ();
@@ -545,14 +545,14 @@ bgp_stop (struct peer *peer)
         peer->afc_adv[afi][safi] = 0;
         peer->afc_recv[afi][safi] = 0;
 
-	/* peer address family capability flags*/
-	peer->af_cap[afi][safi] = 0;
+    /* peer address family capability flags*/
+    peer->af_cap[afi][safi] = 0;
 
-	/* peer address family status flags*/
-	peer->af_sflags[afi][safi] = 0;
+    /* peer address family status flags*/
+    peer->af_sflags[afi][safi] = 0;
 
-	/* Received ORF prefix-filter */
-	peer->orf_plist[afi][safi] = NULL;
+    /* Received ORF prefix-filter */
+    peer->orf_plist[afi][safi] = NULL;
 
         /* ORF received prefix-filter pnt */
         sprintf (orf_name, "%s.%d.%d", peer->host, afi, safi);
@@ -637,7 +637,7 @@ bgp_connect_success (struct peer *peer)
   if (peer->fd < 0)
     {
       zlog_err ("bgp_connect_success peer's fd is negative value %d",
-		peer->fd);
+                peer->fd);
       return -1;
     }
   BGP_READ_ON (peer->t_read, bgp_read, peer->fd);
@@ -645,15 +645,19 @@ bgp_connect_success (struct peer *peer)
   if (! CHECK_FLAG (peer->sflags, PEER_STATUS_ACCEPT_PEER))
     bgp_getsockname (peer);
 
+#ifdef ENABLE_OVSDB
+  bgp_bfd_neigh_add(peer);
+#endif
+
   if (BGP_DEBUG (normal, NORMAL))
     {
       char buf1[SU_ADDRSTRLEN];
 
       if (! CHECK_FLAG (peer->sflags, PEER_STATUS_ACCEPT_PEER))
-	zlog_debug ("%s open active, local address %s", peer->host,
-		    sockunion2str (peer->su_local, buf1, SU_ADDRSTRLEN));
+        zlog_debug ("%s open active, local address %s", peer->host,
+                     sockunion2str (peer->su_local, buf1, SU_ADDRSTRLEN));
       else
-	zlog_debug ("%s passive open", peer->host);
+        zlog_debug ("%s passive open", peer->host);
     }
 
   if (! CHECK_FLAG (peer->sflags, PEER_STATUS_ACCEPT_PEER))
@@ -720,27 +724,27 @@ bgp_start (struct peer *peer)
     {
     case connect_error:
       if (BGP_DEBUG (fsm, FSM))
-	plog_debug (peer->log, "%s [FSM] Connect error", peer->host);
+    plog_debug (peer->log, "%s [FSM] Connect error", peer->host);
       BGP_EVENT_ADD (peer, TCP_connection_open_failed);
       break;
     case connect_success:
       if (BGP_DEBUG (fsm, FSM))
-	plog_debug (peer->log, "%s [FSM] Connect immediately success",
-		   peer->host);
+    plog_debug (peer->log, "%s [FSM] Connect immediately success",
+           peer->host);
       BGP_EVENT_ADD (peer, TCP_connection_open);
       break;
     case connect_in_progress:
       /* To check nonblocking connect, we wait until socket is
          readable or writable. */
       if (BGP_DEBUG (fsm, FSM))
-	plog_debug (peer->log, "%s [FSM] Non blocking connect waiting result",
-		   peer->host);
+    plog_debug (peer->log, "%s [FSM] Non blocking connect waiting result",
+           peer->host);
       if (peer->fd < 0)
-	{
-	  zlog_err ("bgp_start peer's fd is negative value %d",
-		    peer->fd);
-	  return -1;
-	}
+    {
+      zlog_err ("bgp_start peer's fd is negative value %d",
+            peer->fd);
+      return -1;
+    }
       BGP_READ_ON (peer->t_read, bgp_read, peer->fd);
       BGP_WRITE_ON (peer->t_write, bgp_write, peer->fd);
       break;
@@ -783,7 +787,7 @@ static int
 bgp_fsm_event_error (struct peer *peer)
 {
   plog_err (peer->log, "%s [FSM] unexpected packet received in state %s",
-	    peer->host, LOOKUP (bgp_status_msg, peer->status));
+        peer->host, LOOKUP (bgp_status_msg, peer->status));
 
   return bgp_stop_with_notify (peer, BGP_NOTIFY_FSM_ERR, 0);
 }
@@ -835,23 +839,23 @@ bgp_establish (struct peer *peer)
   for (afi = AFI_IP ; afi < AFI_MAX ; afi++)
     for (safi = SAFI_UNICAST ; safi < SAFI_RESERVED_3 ; safi++)
       {
-	if (peer->afc_nego[afi][safi]
-	    && CHECK_FLAG (peer->cap, PEER_CAP_RESTART_ADV)
-	    && CHECK_FLAG (peer->af_cap[afi][safi], PEER_CAP_RESTART_AF_RCV))
-	  {
-	    if (peer->nsf[afi][safi]
-		&& ! CHECK_FLAG (peer->af_cap[afi][safi], PEER_CAP_RESTART_AF_PRESERVE_RCV))
-	      bgp_clear_stale_route (peer, afi, safi);
+    if (peer->afc_nego[afi][safi]
+        && CHECK_FLAG (peer->cap, PEER_CAP_RESTART_ADV)
+        && CHECK_FLAG (peer->af_cap[afi][safi], PEER_CAP_RESTART_AF_RCV))
+      {
+        if (peer->nsf[afi][safi]
+        && ! CHECK_FLAG (peer->af_cap[afi][safi], PEER_CAP_RESTART_AF_PRESERVE_RCV))
+          bgp_clear_stale_route (peer, afi, safi);
 
-	    peer->nsf[afi][safi] = 1;
-	    nsf_af_count++;
-	  }
-	else
-	  {
-	    if (peer->nsf[afi][safi])
-	      bgp_clear_stale_route (peer, afi, safi);
-	    peer->nsf[afi][safi] = 0;
-	  }
+        peer->nsf[afi][safi] = 1;
+        nsf_af_count++;
+      }
+    else
+      {
+        if (peer->nsf[afi][safi])
+          bgp_clear_stale_route (peer, afi, safi);
+        peer->nsf[afi][safi] = 0;
+      }
       }
 
   if (nsf_af_count)
@@ -860,18 +864,18 @@ bgp_establish (struct peer *peer)
     {
       UNSET_FLAG (peer->sflags, PEER_STATUS_NSF_MODE);
       if (peer->t_gr_stale)
-	{
-	  BGP_TIMER_OFF (peer->t_gr_stale);
-	  if (BGP_DEBUG (events, EVENTS))
-	    zlog_debug ("%s graceful restart stalepath timer stopped", peer->host);
-	}
+    {
+      BGP_TIMER_OFF (peer->t_gr_stale);
+      if (BGP_DEBUG (events, EVENTS))
+        zlog_debug ("%s graceful restart stalepath timer stopped", peer->host);
+    }
     }
 
   if (peer->t_gr_restart)
     {
       BGP_TIMER_OFF (peer->t_gr_restart);
       if (BGP_DEBUG (events, EVENTS))
-	zlog_debug ("%s graceful restart timer stopped", peer->host);
+    zlog_debug ("%s graceful restart timer stopped", peer->host);
     }
 
 #ifdef HAVE_SNMP
@@ -885,14 +889,14 @@ bgp_establish (struct peer *peer)
   for (afi = AFI_IP ; afi < AFI_MAX ; afi++)
     for (safi = SAFI_UNICAST ; safi < SAFI_MAX ; safi++)
       if (CHECK_FLAG (peer->af_cap[afi][safi], PEER_CAP_ORF_PREFIX_SM_ADV))
-	{
-	  if (CHECK_FLAG (peer->af_cap[afi][safi], PEER_CAP_ORF_PREFIX_RM_RCV))
-	    bgp_route_refresh_send (peer, afi, safi, ORF_TYPE_PREFIX,
-				    REFRESH_IMMEDIATE, 0);
-	  else if (CHECK_FLAG (peer->af_cap[afi][safi], PEER_CAP_ORF_PREFIX_RM_OLD_RCV))
-	    bgp_route_refresh_send (peer, afi, safi, ORF_TYPE_PREFIX_OLD,
-				    REFRESH_IMMEDIATE, 0);
-	}
+    {
+      if (CHECK_FLAG (peer->af_cap[afi][safi], PEER_CAP_ORF_PREFIX_RM_RCV))
+        bgp_route_refresh_send (peer, afi, safi, ORF_TYPE_PREFIX,
+                    REFRESH_IMMEDIATE, 0);
+      else if (CHECK_FLAG (peer->af_cap[afi][safi], PEER_CAP_ORF_PREFIX_RM_OLD_RCV))
+        bgp_route_refresh_send (peer, afi, safi, ORF_TYPE_PREFIX_OLD,
+                    REFRESH_IMMEDIATE, 0);
+    }
 
   if (peer->v_keepalive)
     bgp_keepalive_send (peer);
@@ -901,9 +905,15 @@ bgp_establish (struct peer *peer)
   for (afi = AFI_IP ; afi < AFI_MAX ; afi++)
     for (safi = SAFI_UNICAST ; safi < SAFI_MAX ; safi++)
       if (CHECK_FLAG (peer->af_cap[afi][safi], PEER_CAP_ORF_PREFIX_RM_ADV))
-	if (CHECK_FLAG (peer->af_cap[afi][safi], PEER_CAP_ORF_PREFIX_SM_RCV)
-	    || CHECK_FLAG (peer->af_cap[afi][safi], PEER_CAP_ORF_PREFIX_SM_OLD_RCV))
-	  SET_FLAG (peer->af_sflags[afi][safi], PEER_STATUS_ORF_WAIT_REFRESH);
+    if (CHECK_FLAG (peer->af_cap[afi][safi], PEER_CAP_ORF_PREFIX_SM_RCV)
+        || CHECK_FLAG (peer->af_cap[afi][safi], PEER_CAP_ORF_PREFIX_SM_OLD_RCV))
+      SET_FLAG (peer->af_sflags[afi][safi], PEER_STATUS_ORF_WAIT_REFRESH);
+
+#ifdef ENABLE_OVSDB
+  /* Notify BFD about the session state, and start it if didn't started yet */
+  if (CHECK_FLAG (peer->flags, PEER_FLAG_BFD))
+    bgp_bfd_neigh_estab(peer);
+#endif
 
   bgp_announce_route_all (peer);
 
@@ -958,67 +968,67 @@ static const struct {
     /* Idle state: In Idle state, all events other than BGP_Start is
        ignored.  With BGP_Start event, finite state machine calls
        bgp_start(). */
-    {bgp_start,  Connect},	/* BGP_Start                    */
-    {bgp_stop,   Idle},		/* BGP_Stop                     */
-    {bgp_stop,   Idle},		/* TCP_connection_open          */
-    {bgp_stop,   Idle},		/* TCP_connection_closed        */
-    {bgp_ignore, Idle},		/* TCP_connection_open_failed   */
-    {bgp_stop,   Idle},		/* TCP_fatal_error              */
-    {bgp_ignore, Idle},		/* ConnectRetry_timer_expired   */
-    {bgp_ignore, Idle},		/* Hold_Timer_expired           */
-    {bgp_ignore, Idle},		/* KeepAlive_timer_expired      */
-    {bgp_ignore, Idle},		/* Receive_OPEN_message         */
-    {bgp_ignore, Idle},		/* Receive_KEEPALIVE_message    */
-    {bgp_ignore, Idle},		/* Receive_UPDATE_message       */
-    {bgp_ignore, Idle},		/* Receive_NOTIFICATION_message */
+    {bgp_start,  Connect},    /* BGP_Start                    */
+    {bgp_stop,   Idle},        /* BGP_Stop                     */
+    {bgp_stop,   Idle},        /* TCP_connection_open          */
+    {bgp_stop,   Idle},        /* TCP_connection_closed        */
+    {bgp_ignore, Idle},        /* TCP_connection_open_failed   */
+    {bgp_stop,   Idle},        /* TCP_fatal_error              */
+    {bgp_ignore, Idle},        /* ConnectRetry_timer_expired   */
+    {bgp_ignore, Idle},        /* Hold_Timer_expired           */
+    {bgp_ignore, Idle},        /* KeepAlive_timer_expired      */
+    {bgp_ignore, Idle},        /* Receive_OPEN_message         */
+    {bgp_ignore, Idle},        /* Receive_KEEPALIVE_message    */
+    {bgp_ignore, Idle},        /* Receive_UPDATE_message       */
+    {bgp_ignore, Idle},        /* Receive_NOTIFICATION_message */
     {bgp_ignore, Idle},         /* Clearing_Completed           */
   },
   {
     /* Connect */
-    {bgp_ignore,  Connect},	/* BGP_Start                    */
-    {bgp_stop,    Idle},	/* BGP_Stop                     */
+    {bgp_ignore,  Connect},    /* BGP_Start                    */
+    {bgp_stop,    Idle},    /* BGP_Stop                     */
     {bgp_connect_success, OpenSent}, /* TCP_connection_open          */
-    {bgp_stop, Idle},		/* TCP_connection_closed        */
+    {bgp_stop, Idle},        /* TCP_connection_closed        */
     {bgp_connect_fail, Active}, /* TCP_connection_open_failed   */
-    {bgp_connect_fail, Idle},	/* TCP_fatal_error              */
-    {bgp_reconnect, Connect},	/* ConnectRetry_timer_expired   */
-    {bgp_ignore,  Idle},	/* Hold_Timer_expired           */
-    {bgp_ignore,  Idle},	/* KeepAlive_timer_expired      */
-    {bgp_ignore,  Idle},	/* Receive_OPEN_message         */
-    {bgp_ignore,  Idle},	/* Receive_KEEPALIVE_message    */
-    {bgp_ignore,  Idle},	/* Receive_UPDATE_message       */
-    {bgp_stop,    Idle},	/* Receive_NOTIFICATION_message */
+    {bgp_connect_fail, Idle},    /* TCP_fatal_error              */
+    {bgp_reconnect, Connect},    /* ConnectRetry_timer_expired   */
+    {bgp_ignore,  Idle},    /* Hold_Timer_expired           */
+    {bgp_ignore,  Idle},    /* KeepAlive_timer_expired      */
+    {bgp_ignore,  Idle},    /* Receive_OPEN_message         */
+    {bgp_ignore,  Idle},    /* Receive_KEEPALIVE_message    */
+    {bgp_ignore,  Idle},    /* Receive_UPDATE_message       */
+    {bgp_stop,    Idle},    /* Receive_NOTIFICATION_message */
     {bgp_ignore,  Idle},         /* Clearing_Completed           */
   },
   {
     /* Active, */
-    {bgp_ignore,  Active},	/* BGP_Start                    */
-    {bgp_stop,    Idle},	/* BGP_Stop                     */
+    {bgp_ignore,  Active},    /* BGP_Start                    */
+    {bgp_stop,    Idle},    /* BGP_Stop                     */
     {bgp_connect_success, OpenSent}, /* TCP_connection_open          */
-    {bgp_stop,    Idle},	/* TCP_connection_closed        */
-    {bgp_ignore,  Active},	/* TCP_connection_open_failed   */
-    {bgp_ignore,  Idle},	/* TCP_fatal_error              */
-    {bgp_start,   Connect},	/* ConnectRetry_timer_expired   */
-    {bgp_ignore,  Idle},	/* Hold_Timer_expired           */
-    {bgp_ignore,  Idle},	/* KeepAlive_timer_expired      */
-    {bgp_ignore,  Idle},	/* Receive_OPEN_message         */
-    {bgp_ignore,  Idle},	/* Receive_KEEPALIVE_message    */
-    {bgp_ignore,  Idle},	/* Receive_UPDATE_message       */
+    {bgp_stop,    Idle},    /* TCP_connection_closed        */
+    {bgp_ignore,  Active},    /* TCP_connection_open_failed   */
+    {bgp_ignore,  Idle},    /* TCP_fatal_error              */
+    {bgp_start,   Connect},    /* ConnectRetry_timer_expired   */
+    {bgp_ignore,  Idle},    /* Hold_Timer_expired           */
+    {bgp_ignore,  Idle},    /* KeepAlive_timer_expired      */
+    {bgp_ignore,  Idle},    /* Receive_OPEN_message         */
+    {bgp_ignore,  Idle},    /* Receive_KEEPALIVE_message    */
+    {bgp_ignore,  Idle},    /* Receive_UPDATE_message       */
     {bgp_stop_with_error, Idle}, /* Receive_NOTIFICATION_message */
     {bgp_ignore, Idle},         /* Clearing_Completed           */
   },
   {
     /* OpenSent, */
-    {bgp_ignore,  OpenSent},	/* BGP_Start                    */
-    {bgp_stop,    Idle},	/* BGP_Stop                     */
-    {bgp_stop,    Active},	/* TCP_connection_open          */
-    {bgp_stop,    Active},	/* TCP_connection_closed        */
-    {bgp_stop,    Active},	/* TCP_connection_open_failed   */
-    {bgp_stop,    Active},	/* TCP_fatal_error              */
-    {bgp_ignore,  Idle},	/* ConnectRetry_timer_expired   */
-    {bgp_fsm_holdtime_expire, Idle},	/* Hold_Timer_expired           */
-    {bgp_ignore,  Idle},	/* KeepAlive_timer_expired      */
-    {bgp_fsm_open,    OpenConfirm},	/* Receive_OPEN_message         */
+    {bgp_ignore,  OpenSent},    /* BGP_Start                    */
+    {bgp_stop,    Idle},    /* BGP_Stop                     */
+    {bgp_stop,    Active},    /* TCP_connection_open          */
+    {bgp_stop,    Active},    /* TCP_connection_closed        */
+    {bgp_stop,    Active},    /* TCP_connection_open_failed   */
+    {bgp_stop,    Active},    /* TCP_fatal_error              */
+    {bgp_ignore,  Idle},    /* ConnectRetry_timer_expired   */
+    {bgp_fsm_holdtime_expire, Idle},    /* Hold_Timer_expired           */
+    {bgp_ignore,  Idle},    /* KeepAlive_timer_expired      */
+    {bgp_fsm_open,    OpenConfirm},    /* Receive_OPEN_message         */
     {bgp_fsm_event_error, Idle}, /* Receive_KEEPALIVE_message    */
     {bgp_fsm_event_error, Idle}, /* Receive_UPDATE_message       */
     {bgp_stop_with_error, Idle}, /* Receive_NOTIFICATION_message */
@@ -1026,18 +1036,18 @@ static const struct {
   },
   {
     /* OpenConfirm, */
-    {bgp_ignore,  OpenConfirm},	/* BGP_Start                    */
-    {bgp_stop,    Idle},	/* BGP_Stop                     */
-    {bgp_stop,    Idle},	/* TCP_connection_open          */
-    {bgp_stop,    Idle},	/* TCP_connection_closed        */
-    {bgp_stop,    Idle},	/* TCP_connection_open_failed   */
-    {bgp_stop,    Idle},	/* TCP_fatal_error              */
-    {bgp_ignore,  Idle},	/* ConnectRetry_timer_expired   */
-    {bgp_fsm_holdtime_expire, Idle},	/* Hold_Timer_expired           */
-    {bgp_ignore,  OpenConfirm},	/* KeepAlive_timer_expired      */
-    {bgp_ignore,  Idle},	/* Receive_OPEN_message         */
+    {bgp_ignore,  OpenConfirm},    /* BGP_Start                    */
+    {bgp_stop,    Idle},    /* BGP_Stop                     */
+    {bgp_stop,    Idle},    /* TCP_connection_open          */
+    {bgp_stop,    Idle},    /* TCP_connection_closed        */
+    {bgp_stop,    Idle},    /* TCP_connection_open_failed   */
+    {bgp_stop,    Idle},    /* TCP_fatal_error              */
+    {bgp_ignore,  Idle},    /* ConnectRetry_timer_expired   */
+    {bgp_fsm_holdtime_expire, Idle},    /* Hold_Timer_expired           */
+    {bgp_ignore,  OpenConfirm},    /* KeepAlive_timer_expired      */
+    {bgp_ignore,  Idle},    /* Receive_OPEN_message         */
     {bgp_establish, Established}, /* Receive_KEEPALIVE_message    */
-    {bgp_ignore,  Idle},	/* Receive_UPDATE_message       */
+    {bgp_ignore,  Idle},    /* Receive_UPDATE_message       */
     {bgp_stop_with_error, Idle}, /* Receive_NOTIFICATION_message */
     {bgp_ignore, Idle},         /* Clearing_Completed           */
   },
@@ -1047,9 +1057,9 @@ static const struct {
     {bgp_stop,                    Clearing}, /* BGP_Stop                     */
     {bgp_stop,                    Clearing}, /* TCP_connection_open          */
     {bgp_stop,                    Clearing}, /* TCP_connection_closed        */
-    {bgp_stop,                 Clearing},	/* TCP_connection_open_failed   */
+    {bgp_stop,                 Clearing},    /* TCP_connection_open_failed   */
     {bgp_stop,                    Clearing}, /* TCP_fatal_error              */
-    {bgp_stop,                 Clearing},	/* ConnectRetry_timer_expired   */
+    {bgp_stop,                 Clearing},    /* ConnectRetry_timer_expired   */
     {bgp_fsm_holdtime_expire,     Clearing}, /* Hold_Timer_expired           */
     {bgp_fsm_keepalive_expire, Established}, /* KeepAlive_timer_expired      */
     {bgp_stop,                    Clearing}, /* Receive_OPEN_message         */
@@ -1060,37 +1070,37 @@ static const struct {
   },
   {
     /* Clearing, */
-    {bgp_ignore,  Clearing},	/* BGP_Start                    */
-    {bgp_stop,			Clearing},	/* BGP_Stop                     */
-    {bgp_stop,			Clearing},	/* TCP_connection_open          */
-    {bgp_stop,			Clearing},	/* TCP_connection_closed        */
-    {bgp_stop,			Clearing},	/* TCP_connection_open_failed   */
-    {bgp_stop,			Clearing},	/* TCP_fatal_error              */
-    {bgp_stop,			Clearing},	/* ConnectRetry_timer_expired   */
-    {bgp_stop,			Clearing},	/* Hold_Timer_expired           */
-    {bgp_stop,			Clearing},	/* KeepAlive_timer_expired      */
-    {bgp_stop,			Clearing},	/* Receive_OPEN_message         */
-    {bgp_stop,			Clearing},	/* Receive_KEEPALIVE_message    */
-    {bgp_stop,			Clearing},	/* Receive_UPDATE_message       */
-    {bgp_stop,			Clearing},	/* Receive_NOTIFICATION_message */
-    {bgp_clearing_completed,    Idle},		/* Clearing_Completed           */
+    {bgp_ignore,  Clearing},    /* BGP_Start                    */
+    {bgp_stop,            Clearing},    /* BGP_Stop                     */
+    {bgp_stop,            Clearing},    /* TCP_connection_open          */
+    {bgp_stop,            Clearing},    /* TCP_connection_closed        */
+    {bgp_stop,            Clearing},    /* TCP_connection_open_failed   */
+    {bgp_stop,            Clearing},    /* TCP_fatal_error              */
+    {bgp_stop,            Clearing},    /* ConnectRetry_timer_expired   */
+    {bgp_stop,            Clearing},    /* Hold_Timer_expired           */
+    {bgp_stop,            Clearing},    /* KeepAlive_timer_expired      */
+    {bgp_stop,            Clearing},    /* Receive_OPEN_message         */
+    {bgp_stop,            Clearing},    /* Receive_KEEPALIVE_message    */
+    {bgp_stop,            Clearing},    /* Receive_UPDATE_message       */
+    {bgp_stop,            Clearing},    /* Receive_NOTIFICATION_message */
+    {bgp_clearing_completed,    Idle},        /* Clearing_Completed           */
   },
   {
     /* Deleted, */
-    {bgp_ignore,  Deleted},	/* BGP_Start                    */
-    {bgp_ignore,  Deleted},	/* BGP_Stop                     */
-    {bgp_ignore,  Deleted},	/* TCP_connection_open          */
-    {bgp_ignore,  Deleted},	/* TCP_connection_closed        */
-    {bgp_ignore,  Deleted},	/* TCP_connection_open_failed   */
-    {bgp_ignore,  Deleted},	/* TCP_fatal_error              */
-    {bgp_ignore,  Deleted},	/* ConnectRetry_timer_expired   */
-    {bgp_ignore,  Deleted},	/* Hold_Timer_expired           */
-    {bgp_ignore,  Deleted},	/* KeepAlive_timer_expired      */
-    {bgp_ignore,  Deleted},	/* Receive_OPEN_message         */
-    {bgp_ignore,  Deleted},	/* Receive_KEEPALIVE_message    */
-    {bgp_ignore,  Deleted},	/* Receive_UPDATE_message       */
-    {bgp_ignore,  Deleted},	/* Receive_NOTIFICATION_message */
-    {bgp_ignore,  Deleted},	/* Clearing_Completed           */
+    {bgp_ignore,  Deleted},    /* BGP_Start                    */
+    {bgp_ignore,  Deleted},    /* BGP_Stop                     */
+    {bgp_ignore,  Deleted},    /* TCP_connection_open          */
+    {bgp_ignore,  Deleted},    /* TCP_connection_closed        */
+    {bgp_ignore,  Deleted},    /* TCP_connection_open_failed   */
+    {bgp_ignore,  Deleted},    /* TCP_fatal_error              */
+    {bgp_ignore,  Deleted},    /* ConnectRetry_timer_expired   */
+    {bgp_ignore,  Deleted},    /* Hold_Timer_expired           */
+    {bgp_ignore,  Deleted},    /* KeepAlive_timer_expired      */
+    {bgp_ignore,  Deleted},    /* Receive_OPEN_message         */
+    {bgp_ignore,  Deleted},    /* Receive_KEEPALIVE_message    */
+    {bgp_ignore,  Deleted},    /* Receive_UPDATE_message       */
+    {bgp_ignore,  Deleted},    /* Receive_NOTIFICATION_message */
+    {bgp_ignore,  Deleted},    /* Clearing_Completed           */
   },
 };
 
@@ -1130,9 +1140,9 @@ bgp_event (struct thread *thread)
 
   if (BGP_DEBUG (fsm, FSM) && peer->status != next)
     plog_debug (peer->log, "%s [FSM] %s (%s->%s)", peer->host, 
-	       bgp_event_str[event],
-	       LOOKUP (bgp_status_msg, peer->status),
-	       LOOKUP (bgp_status_msg, next));
+           bgp_event_str[event],
+           LOOKUP (bgp_status_msg, peer->status),
+           LOOKUP (bgp_status_msg, next));
 
   /* Call function. */
   if (FSM [peer->status -1][event - 1].func)

--- a/bgpd/bgp_ovsdb_if.c
+++ b/bgpd/bgp_ovsdb_if.c
@@ -331,6 +331,8 @@ bgp_ovsdb_tables_init (struct ovsdb_idl *idl)
     ovsdb_idl_add_column(idl, &ovsrec_bgp_neighbor_col_bgp_peer_group);
     ovsdb_idl_add_column(idl, &ovsrec_bgp_neighbor_col_local_interface);
     ovsdb_idl_add_column(idl, &ovsrec_bgp_neighbor_col_remote_as);
+    ovsdb_idl_add_column(idl, &ovsrec_bgp_neighbor_col_bfd_fallover_enable);
+    ovsdb_idl_add_column(idl, &ovsrec_bgp_neighbor_col_bfd_session);
     ovsdb_idl_add_column(idl, &ovsrec_bgp_neighbor_col_allow_as_in);
     ovsdb_idl_add_column(idl, &ovsrec_bgp_neighbor_col_local_as);
     ovsdb_idl_add_column(idl, &ovsrec_bgp_neighbor_col_weight);
@@ -393,6 +395,18 @@ bgp_ovsdb_tables_init (struct ovsdb_idl *idl)
     ovsdb_idl_add_table(idl, &ovsrec_table_bgp_nexthop);
     ovsdb_idl_add_column(idl, &ovsrec_bgp_nexthop_col_ip_address);
     ovsdb_idl_add_column(idl, &ovsrec_bgp_nexthop_col_type);
+
+    /* BFD Session table */
+    ovsdb_idl_add_table(idl, &ovsrec_table_bfd_session);
+    ovsdb_idl_add_column(idl, &ovsrec_bfd_session_col_enable);
+    ovsdb_idl_add_column(idl, &ovsrec_bfd_session_col_bfd_dst_ip);
+    ovsdb_idl_add_column(idl, &ovsrec_bfd_session_col_bfd_src_ip);
+    ovsdb_idl_add_column(idl, &ovsrec_bfd_session_col_min_tx);
+    ovsdb_idl_add_column(idl, &ovsrec_bfd_session_col_min_rx);
+    ovsdb_idl_add_column(idl, &ovsrec_bfd_session_col_decay_min_rx);
+    ovsdb_idl_add_column(idl, &ovsrec_bfd_session_col_state);
+    ovsdb_idl_track_add_column(idl, &ovsrec_bfd_session_col_state);
+    ovsdb_idl_add_column(idl, &ovsrec_bfd_session_col_from);
 }
 
 /*
@@ -1968,7 +1982,7 @@ get_bgp_neighbor_with_VrfName_BgpRouterAsn_Ipaddr (struct ovsdb_idl *idl,
     const struct ovsrec_bgp_router *ovs_bgp;
 
     if (NULL == vrf_name) {
-	vrf_name = DEFAULT_VRF_NAME;
+    vrf_name = DEFAULT_VRF_NAME;
     }
 
     OVSREC_VRF_FOR_EACH(ovs_vrf, idl) {
@@ -2011,7 +2025,7 @@ bgp_daemon_ovsdb_neighbor_statistics_update (bool start_new_db_txn,
     struct peer *peer)
 {
 
-#define MAX_BGP_NEIGHBOR_STATS		64
+#define MAX_BGP_NEIGHBOR_STATS        64
 
     struct ovsdb_idl_txn *db_txn;
     char *keywords[MAX_BGP_NEIGHBOR_STATS];
@@ -2064,7 +2078,7 @@ bgp_daemon_ovsdb_neighbor_statistics_update (bool start_new_db_txn,
     ADD_BGPN_STAT(BGP_PEER_RESETTIME, peer->resettime);
 
     ovsrec_bgp_neighbor_set_statistics(ovs_bgp_neighbor_ptr,
-	keywords, values, count);
+    keywords, values, count);
 
     if (start_new_db_txn) {
         status = ovsdb_idl_txn_commit(db_txn);
@@ -2099,15 +2113,15 @@ void bgp_daemon_ovsdb_neighbor_update (struct peer *peer,
 
     db_txn = ovsdb_idl_txn_create(idl);
     if (NULL == db_txn) {
-	VLOG_ERR("%%ovsdb_idl_txn_create failed in "
-	    "bgp_daemon_ovsdb_neighbor_update\n");
-	return;
+    VLOG_ERR("%%ovsdb_idl_txn_create failed in "
+        "bgp_daemon_ovsdb_neighbor_update\n");
+    return;
     }
 
     /* update fields of this peer/neighbor in the ovsdb */
 
     if (peer->group) {
-	/* TO DO LATER */
+    /* TO DO LATER */
     }
 
     VLOG_DBG("updating port to %d\n", peer->port);
@@ -2129,14 +2143,14 @@ void bgp_daemon_ovsdb_neighbor_update (struct peer *peer,
     smap_init(&smap);
     smap_add(&smap, BGP_PEER_STATE, bgp_peer_status_to_string(peer->status));
     VLOG_DBG("updating bgp neighbor status to %s\n",
-	bgp_peer_status_to_string(peer->status));
+    bgp_peer_status_to_string(peer->status));
     ovsrec_bgp_neighbor_set_status(ovs_bgp_neighbor_ptr, &smap);
 
     /* update statistics */
     if (update_stats_too) {
-	bgp_daemon_ovsdb_neighbor_statistics_update(false,
-	    ovs_bgp_neighbor_ptr, peer);
-	VLOG_DBG("updated stats also\n");
+    bgp_daemon_ovsdb_neighbor_statistics_update(false,
+        ovs_bgp_neighbor_ptr, peer);
+    VLOG_DBG("updated stats also\n");
     }
 
     status = ovsdb_idl_txn_commit(db_txn);
@@ -2170,6 +2184,70 @@ bgp_nbr_remote_as_ovsdb_apply_changes (const struct ovsrec_bgp_neighbor *ovs_nbr
         VLOG_DBG("Setting remote-as %lld", *ovs_nbr->remote_as);
         daemon_neighbor_remote_as_cmd_execute(bgp_instance,
             name, (as_t *)ovs_nbr->remote_as, AFI_IP, SAFI_UNICAST);
+    }
+}
+
+static void
+bgp_nbr_fallover_ovsdb_apply_changes (const struct ovsrec_bgp_neighbor *ovs_nbr,
+    char * name,
+    struct bgp *bgp_instance)
+{
+    bool is_set = (ovs_nbr->bfd_fallover_enable) ? true : false;
+
+    /* fallover */
+    if (COL_CHANGED(ovs_nbr, ovsrec_bgp_neighbor_col_bfd_fallover_enable, idl_seqno)) {
+        VLOG_DBG("Fallover BFD %s for %s", (is_set) ? "Enable" : "Disable", name);
+        daemon_neighbor_bfd_fallover_enable_cmd_execute(bgp_instance, name, is_set);
+    }
+}
+
+static int
+bfd_session_state_string_to_enum (const char *state_str)
+{
+    if (!state_str)
+        return BFD_SESSION_STATE_ADMIN_DOWN;
+
+    VLOG_DBG("bfd_session_state_string_to_enum: input string is %s", state_str);
+
+    if (strcmp(state_str, BFD_SESSION_STATE_STR_ADMIN_DOWN) == 0)
+        return BFD_SESSION_STATE_ADMIN_DOWN;
+    else if (strcmp(state_str, BFD_SESSION_STATE_STR_DOWN) == 0)
+        return BFD_SESSION_STATE_DOWN;
+    else if (strcmp(state_str, BFD_SESSION_STATE_STR_INIT) == 0)
+        return BFD_SESSION_STATE_INIT;
+    else if (strcmp(state_str, BFD_SESSION_STATE_STR_UP) == 0)
+        return BFD_SESSION_STATE_UP;
+
+    return BFD_SESSION_STATE_ADMIN_DOWN;
+}
+
+static void
+bgp_nbr_bfd_session_ovsdb_apply_changes (const struct ovsrec_bgp_neighbor *ovs_nbr,
+    char *name, struct bgp *bgp_instance, bool bfd_session_changed)
+{
+    const struct ovsrec_bfd_session *ovs_bfd_session;
+    int bfd_state;
+
+    VLOG_DBG("BGP-BFD: bgp_nbr_bfd_session_ovsdb_apply_changes: %s\n", name);
+
+    if (!ovs_nbr->bfd_session)
+        return;
+
+    ovs_bfd_session = (struct ovsrec_bfd_session *)ovs_nbr->bfd_session;
+
+    /* BFD Session Update */
+    // FIXME - Fix this to invoke only when there is a change!!
+    // for some reason COL_CHANGED or ROW_CHANGED are not getting triggered
+    if (COL_CHANGED(ovs_bfd_session, ovsrec_bfd_session_col_state, idl_seqno) ||
+        ROW_CHANGED(ovs_bfd_session, idl_seqno) ||
+        bfd_session_changed)
+    {
+        if (ovs_bfd_session->state) {
+            bfd_state = bfd_session_state_string_to_enum (ovs_bfd_session->state);
+            VLOG_DBG("BGP-BFD: BFD_Session state changed to %s for %s\n",
+                     ovs_bfd_session->state, name);
+            daemon_neighbor_bfd_state_cmd_execute(bgp_instance, name, bfd_state);
+        }
     }
 }
 
@@ -2664,7 +2742,7 @@ bgp_check_neighbor_clear_soft_out (struct ovsdb_idl *idl,
  * Do bgp nbr changes according to ovsdb changes
  */
 static void
-bgp_nbr_read_ovsdb_apply_changes (struct ovsdb_idl *idl)
+bgp_nbr_read_ovsdb_apply_changes (struct ovsdb_idl *idl, bool bfd_session_changed)
 {
     const struct ovsrec_vrf *ovs_vrf = NULL;
     const struct ovsrec_bgp_router *ovs_bgp;
@@ -2692,7 +2770,8 @@ bgp_nbr_read_ovsdb_apply_changes (struct ovsdb_idl *idl)
             ovs_nbr = ovs_bgp->value_bgp_neighbors[j];
 
             if (!OVSREC_IDL_IS_ROW_INSERTED(ovs_nbr, idl_seqno) &&
-                !OVSREC_IDL_IS_ROW_MODIFIED(ovs_nbr, idl_seqno)) {
+                !OVSREC_IDL_IS_ROW_MODIFIED(ovs_nbr, idl_seqno) &&
+                !bfd_session_changed) {
                     continue;
             }
 
@@ -2726,7 +2805,13 @@ bgp_nbr_read_ovsdb_apply_changes (struct ovsdb_idl *idl)
                 }
             }
 
+            /* fallover */
+            bgp_nbr_fallover_ovsdb_apply_changes(ovs_nbr,
+                ovs_bgp->key_bgp_neighbors[j], bgp_instance);
 
+            /* bfd-session update */
+            bgp_nbr_bfd_session_ovsdb_apply_changes(ovs_nbr,
+                ovs_bgp->key_bgp_neighbors[j], bgp_instance, bfd_session_changed);
 
             /* Create a confirmed database transaction for nbr updates */
             if (!confirm_txn) {
@@ -2768,7 +2853,7 @@ bgp_nbr_read_ovsdb_apply_changes (struct ovsdb_idl *idl)
                           req_cnt_in, perf_cnt_in, req_cnt_out, perf_cnt_out);
             }
 
-	    /* remote-as */
+        /* remote-as */
             bgp_nbr_remote_as_ovsdb_apply_changes(ovs_nbr,
                 ovs_bgp->key_bgp_neighbors[j], bgp_instance);
 
@@ -2776,11 +2861,11 @@ bgp_nbr_read_ovsdb_apply_changes (struct ovsdb_idl *idl)
             bgp_nbr_peer_group_ovsdb_apply_changes(ovs_nbr, ovs_bgp,
                 ovs_bgp->key_bgp_neighbors[j], bgp_instance);
 
-	    /* description */
+        /* description */
             bgp_nbr_description_ovsdb_apply_changes(ovs_nbr, ovs_bgp,
                 ovs_bgp->key_bgp_neighbors[j], bgp_instance);
 
-	    /* passwd */
+        /* passwd */
             bgp_nbr_password_ovsdb_apply_changes(ovs_nbr, ovs_bgp,
                 ovs_bgp->key_bgp_neighbors[j], bgp_instance);
 
@@ -2788,11 +2873,11 @@ bgp_nbr_read_ovsdb_apply_changes (struct ovsdb_idl *idl)
             bgp_nbr_shutdown_ovsdb_apply_changes(ovs_nbr, ovs_bgp,
                 ovs_bgp->key_bgp_neighbors[j], bgp_instance);
 
-	    /* inbound_soft_reconfiguration */
+        /* inbound_soft_reconfiguration */
             bgp_nbr_inbound_soft_reconfig_ovsdb_apply_changes(ovs_nbr, ovs_bgp,
                 ovs_bgp->key_bgp_neighbors[j], bgp_instance);
 
-	    /* route map */
+        /* route map */
             bgp_nbr_route_map_ovsdb_apply_changes(ovs_nbr, ovs_bgp,
                 ovs_bgp->key_bgp_neighbors[j], bgp_instance);
 
@@ -2804,11 +2889,11 @@ bgp_nbr_read_ovsdb_apply_changes (struct ovsdb_idl *idl)
             bgp_nbr_aspath_filter_ovsdb_apply_changes(ovs_nbr, ovs_bgp,
                 ovs_bgp->key_bgp_neighbors[j], bgp_instance);
 
-	    /* timers */
+        /* timers */
             bgp_nbr_timers_ovsdb_apply_changes(ovs_nbr, ovs_bgp,
                 ovs_bgp->key_bgp_neighbors[j], bgp_instance);
 
-	    /* allow_as_in */
+        /* allow_as_in */
             bgp_nbr_allow_as_in_ovsdb_apply_changes(ovs_nbr, ovs_bgp,
                 ovs_bgp->key_bgp_neighbors[j], bgp_instance);
 
@@ -2820,15 +2905,15 @@ bgp_nbr_read_ovsdb_apply_changes (struct ovsdb_idl *idl)
             bgp_nbr_advertisement_interval_ovsdb_apply_changes(ovs_nbr, ovs_bgp,
                 ovs_bgp->key_bgp_neighbors[j], bgp_instance);
 
-	    /* ebgp_multihop */
+        /* ebgp_multihop */
             bgp_nbr_ebgp_multihop_ovsdb_apply_changes(ovs_nbr, ovs_bgp,
                 ovs_bgp->key_bgp_neighbors[j], bgp_instance);
 
-	    /* ttl_security_hops */
+        /* ttl_security_hops */
             bgp_nbr_ttl_security_hops_ovsdb_apply_changes(ovs_nbr, ovs_bgp,
                 ovs_bgp->key_bgp_neighbors[j], bgp_instance);
 
-	    /* update_source */
+        /* update_source */
             bgp_nbr_update_source_ovsdb_apply_changes(ovs_nbr, ovs_bgp,
                 ovs_bgp->key_bgp_neighbors[j], bgp_instance);
 
@@ -2845,6 +2930,8 @@ bgp_apply_bgp_neighbor_changes (struct ovsdb_idl *idl)
 {
     const struct ovsrec_bgp_bgp *ovs_bgp;
     const struct ovsrec_bgp_neighbor *ovs_nbr;
+    const struct ovsrec_bfd_session *ovs_bfd_session;
+    bool bfd_session_changed = false;
     struct bgp *bgp_instance;
     bool inserted = false;
     bool modified = false;
@@ -2863,17 +2950,25 @@ bgp_apply_bgp_neighbor_changes (struct ovsdb_idl *idl)
      * it follows that modified or inserted can NOT be true.
      */
     if (!ovs_nbr) {
-	deleted = true;
+    deleted = true;
     } else {
-	if (ANY_ROW_DELETED(ovs_nbr, idl_seqno)) {
-	    deleted = true;
-	}
-	if (ANY_NEW_ROW(ovs_nbr, idl_seqno)) {
-	    inserted = true;
-	}
-	if (ANY_ROW_CHANGED(ovs_nbr, idl_seqno)) {
-	    modified = true;
-	}
+    if (ANY_ROW_DELETED(ovs_nbr, idl_seqno)) {
+        deleted = true;
+    }
+    if (ANY_NEW_ROW(ovs_nbr, idl_seqno)) {
+        inserted = true;
+    }
+    if (ANY_ROW_CHANGED(ovs_nbr, idl_seqno)) {
+        modified = true;
+    }
+
+        OVSREC_BFD_SESSION_FOR_EACH(ovs_bfd_session, idl) {
+            if (OVSREC_IDL_IS_ROW_INSERTED(ovs_bfd_session, idl_seqno) ||
+                OVSREC_IDL_IS_ROW_MODIFIED(ovs_bfd_session, idl_seqno)) {
+                bfd_session_changed = true;
+                break;
+            }
+        }
     }
 
     /* deletions are handled differently, do them first */
@@ -2883,13 +2978,107 @@ bgp_apply_bgp_neighbor_changes (struct ovsdb_idl *idl)
     }
 
     /* nothing else changed ? */
-    if (!modified && !inserted) {
-	VLOG_DBG("no other changes occured in BGP Neighbor table\n");
-	return;
+    if (!modified && !inserted && !bfd_session_changed) {
+    VLOG_DBG("no other changes occured in BGP Neighbor table\n");
+    return;
     }
 
     VLOG_DBG("now processing bgp neighbor modifications\n");
-    bgp_nbr_read_ovsdb_apply_changes(idl);
+    bgp_nbr_read_ovsdb_apply_changes(idl, bfd_session_changed);
+}
+
+static const struct ovsrec_bfd_session *
+find_matching_bfd_session_in_ovsdb(struct ovsdb_idl *idl, const char *remote)
+{
+        const struct ovsrec_bfd_session *ovs_bfd_session;
+
+        OVSREC_BFD_SESSION_FOR_EACH(ovs_bfd_session, idl) {
+                if (strcmp(ovs_bfd_session->bfd_dst_ip, remote) == 0) {
+                        return ovs_bfd_session;
+                }
+        }
+        return NULL;
+}
+
+void
+bgp_create_bfd_session_in_ovsdb(char *remote, char *local, as_t asn)
+{
+    const struct ovsrec_bgp_neighbor *ovs_nbr;
+    const struct ovsrec_bfd_session *ovs_bfd_session;
+    struct ovsdb_idl_txn *ovs_txn=NULL;
+    enum ovsdb_idl_txn_status status;
+
+    VLOG_DBG("Creating BFD session in DB for remote=%s local=%s\n", remote, local);
+
+    ovs_nbr = get_bgp_neighbor_with_VrfName_BgpRouterAsn_Ipaddr(idl, NULL, asn, remote);
+    if (!ovs_nbr) {
+        VLOG_ERR("BGP-BFD: BGP Neighbor not found for %s, asn=%d", remote, asn);
+        return;
+    }
+
+    /*
+     * TODO: bgp_txn_finish() needs be added here after rel/dill merge
+     */
+    ovs_txn = ovsdb_idl_txn_create(idl);
+
+    ovs_bfd_session = find_matching_bfd_session_in_ovsdb(idl, remote);
+    if (ovs_bfd_session) {
+      VLOG_INFO("BFD session exists for remote=%s local=%s\n", remote, local);
+      if (strcmp(ovs_bfd_session->bfd_src_ip, local) == 0) {
+          VLOG_INFO("DB has the correct BFD Session info already! \n");
+      } else {
+          ovsrec_bfd_session_set_bfd_src_ip(ovs_bfd_session, local);
+      }
+    } else {
+      ovs_bfd_session = ovsrec_bfd_session_insert(ovs_txn);
+      if (ovs_bfd_session) {
+          VLOG_DBG("New BFD Session created for remote %s local %s \n", remote, local);
+          ovsrec_bfd_session_set_bfd_dst_ip(ovs_bfd_session, remote);
+          ovsrec_bfd_session_set_bfd_src_ip(ovs_bfd_session, local);
+          ovsrec_bfd_session_set_from(ovs_bfd_session, OVSREC_BFD_SESSION_FROM_BGP);
+          ovsrec_bgp_neighbor_set_bfd_session(ovs_nbr, ovs_bfd_session);
+      }
+    }
+
+    status = ovsdb_idl_txn_commit(ovs_txn);
+    VLOG_DBG("BGP-BFD: create BFD Session for remote=%s local=%s : commit status %s",
+             remote, local, ovsdb_idl_txn_status_to_string(status));
+    ovsdb_idl_txn_destroy(ovs_txn);
+}
+
+void
+bgp_delete_bfd_session_in_ovsdb(char *remote, as_t asn)
+{
+    const struct ovsrec_bgp_neighbor *ovs_nbr;
+    const struct ovsrec_bfd_session *ovs_bfd_session;
+    struct ovsdb_idl_txn *ovs_txn=NULL;
+    enum ovsdb_idl_txn_status status;
+    const int64_t asid = asn;
+
+    VLOG_DBG("Delete BDF session in DB for remote=%s\n", remote);
+
+    ovs_nbr = get_bgp_neighbor_with_VrfName_BgpRouterAsn_Ipaddr(idl, NULL, asn, remote);
+    if (!ovs_nbr) {
+        VLOG_ERR("BGP-BFD: BGP Neighbor not found for %s, asn=%d", remote, asn);
+        return;
+    }
+
+    /*
+     * TODO: bgp_txn_finish() needs be added here after rel/dill merge
+     */
+    ovs_txn = ovsdb_idl_txn_create(idl);
+
+    ovs_bfd_session = find_matching_bfd_session_in_ovsdb(idl, remote);
+    if (ovs_bfd_session) {
+        VLOG_INFO("Session found, proceeding to delete BFD session for remote=%s \n", remote);
+        ovsrec_bgp_neighbor_set_bfd_session(ovs_nbr, NULL);
+        ovsrec_bfd_session_delete(ovs_bfd_session);
+    }
+
+    status = ovsdb_idl_txn_commit(ovs_txn);
+    VLOG_DBG("BGP-BFD: Delete BFD Session for remote=%s: commit status %s",
+            remote, ovsdb_idl_txn_status_to_string(status));
+    ovsdb_idl_txn_destroy(ovs_txn);
 }
 
 static void

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -356,6 +356,11 @@ struct peer
   int shared_network;		/* Is this peer shared same network. */
   struct bgp_nexthop nexthop;	/* Nexthop */
 
+#ifdef ENABLE_OVSDB
+  /* BFD section */
+  int bfd_status;	/* status of BFD session */
+#endif
+
   /* Peer address family configuration. */
   u_char afc[AFI_MAX][SAFI_MAX];
   u_char afc_nego[AFI_MAX][SAFI_MAX];
@@ -398,6 +403,9 @@ struct peer
 #define PEER_FLAG_DISABLE_CONNECTED_CHECK   (1 << 6) /* disable-connected-check */
 #define PEER_FLAG_LOCAL_AS_NO_PREPEND       (1 << 7) /* local-as no-prepend */
 #define PEER_FLAG_LOCAL_AS_REPLACE_AS       (1 << 8) /* local-as no-prepend replace-as */
+#ifdef ENABLE_OVSDB
+#define PEER_FLAG_BFD                       (1 << 9) /* fall-over bfd */
+#endif
 
   /* NSF mode (graceful restart) */
   u_char nsf[AFI_MAX][SAFI_MAX];

--- a/ops-tests/component/ospf/test_ospfv2_ct_verify_config.py
+++ b/ops-tests/component/ospf/test_ospfv2_ct_verify_config.py
@@ -1,0 +1,58 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2015-2016 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from time import sleep
+
+TOPOLOGY = """
+#
+#
+# +-------+
+# +  sw1  +
+# +-------+
+#
+#
+
+# Nodes
+[type=openswitch name="Switch 1"] sw1
+
+"""
+
+def test_ospf_ct_verify_router_id(topology, step):
+    sw = topology.get('sw1')
+    ospf_auto_router_id = "192.168.1.1"
+    ospf_man_router_id = "1.1.1.1"
+    lo2_addr = "172.16.1.1"
+    assert sw is not None
+
+    step('### Test to verify correct OSPF router-id assignment ###')
+    step('### 1. Test that router-id is assigned automatically from VRF table ###')
+    sw("configure terminal")
+    sw("interface loopback 1")
+    sw("ip address %s/32" % ospf_auto_router_id)
+    sw("exit")
+    sw("configure terminal")
+    sw("interface loopback 2")
+    sw("ip address %s/32" % lo2_addr)
+    sw("exit")
+    sw("router ospf")
+    ospf_cfg = sw("do show ip ospf")
+    assert "Router ID:  %s" % ospf_auto_router_id in ospf_cfg
+    step('### 2. Test that manually set router-id overrides automatically assigned ###')
+    sw("router-id %s" % ospf_man_router_id)
+    ospf_cfg = sw("do show ip ospf")
+    assert "Router ID:  %s" % ospf_man_router_id in ospf_cfg
+    step('### Router-id is correct, test passed ###')

--- a/ops-tests/component/zebra/test_zebra_ct_diagnostics.py
+++ b/ops-tests/component/zebra/test_zebra_ct_diagnostics.py
@@ -102,12 +102,6 @@ def test_zebra_diag_dump(topology, step):
     assert '-------- Zebra memory dump: --------' in output, \
            'Missing memory dump in "zebra/dump" output'
 
-    step('### Testing invalid arguments to "ovs-appctl -t ops-zebra zebra/diag" ###')
-    output = sw1("ovs-appctl -t ops-zebra zebra/diag -1", shell="bash")
-    assert 'Buffer length can only be set to a positive integer value' in output, \
-           '"ovs-appctl -t ops-zebra zebra/diag" should only accept positive \
-           integer values'
-
     step('### Testing invalid arguments to "ovs-appctl -t ops-zebra zebra/debug" ###')
     output = sw1("ovs-appctl -t ops-zebra zebra/debug unsupported", shell="bash")
     assert 'Unsupported argument - unsupported' in output, \

--- a/ops-tests/feature/bgp/interface_utils.py
+++ b/ops-tests/feature/bgp/interface_utils.py
@@ -1,0 +1,377 @@
+# (C) Copyright 2016 Hewlett Packard Enterprise Development LP
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+#
+
+
+"""
+OpenSwitch Test Utility for BGP
+"""
+
+# from pytest import set_trace
+import re
+from time import sleep
+from functools import wraps
+
+def find_device_label(sw, interface):
+    assert interface in sw.ports.values()
+    for key, value in sw.ports.items():
+        if value == interface:
+            return key
+
+def turn_on_interface(sw, interface):
+    port = find_device_label(sw, interface)
+    with sw.libs.vtysh.ConfigInterface(port) as ctx:
+        ctx.no_shutdown()
+
+
+def turn_off_interface(sw, interface):
+    port = find_device_label(sw, interface)
+    with sw.libs.vtysh.ConfigInterface(port) as ctx:
+        ctx.shutdown()
+
+
+def validate_turn_on_interfaces(sw, interfaces):
+    for intf in interfaces:
+        port = find_device_label(sw, intf)
+        output = sw.libs.vtysh.show_interface(port)
+        assert output['interface_state'] == 'up',\
+            "Interface state for " + intf + " is down"
+
+
+def validate_turn_off_interfaces(sw, interfaces):
+    for intf in interfaces:
+        port = find_device_label(sw, intf)
+        output = sw.libs.vtysh.show_interface(port)
+        assert output['interface_state'] == 'down',\
+            "Interface state for " + port + "is up"
+
+
+def verify_turn_off_interfaces(sw, intf_list):
+    @retry_wrapper(
+        'Ensure interfaces are turn off',
+        'Interfaces not yet ready',
+        5,
+        60)
+    def check_interfaces(sw):
+        validate_turn_off_interfaces(sw, intf_list)
+    check_interfaces(sw)
+
+def get_device_mac_address(sw, interface):
+    cmd_output = sw('ifconfig'.format(**locals()),
+                    shell='bash_swns')
+    mac_re = (r'' + interface + '\s*Link\sencap:Ethernet\s*HWaddr\s'
+              r'(?P<mac_address>([0-9A-Fa-f]{2}[:-]){5}'
+              r'[0-9A-Fa-f]{2})')
+
+    re_result = re.search(mac_re, cmd_output)
+    assert re_result
+
+    result = re_result.groupdict()
+    print(result)
+
+    return result['mac_address']
+
+
+def tcpdump_capture_interface(sw, interface_id, wait_time):
+    cmd_output = sw('tcpdump -D'.format(**locals()),
+                    shell='bash_swns')
+    interface_re = (r'(?P<linux_interface>\d)\.' + interface_id +
+                    r'\s[\[Up, Running\]]')
+    re_result = re.search(interface_re, cmd_output)
+    assert re_result
+    result = re_result.groupdict()
+
+    sw('tcpdump -ni ' + result['linux_interface'] +
+        ' -e ether proto ' + LACP_PROTOCOL + ' -vv'
+        '> /tmp/interface.cap 2>&1 &'.format(**locals()),
+        shell='bash_swns')
+
+    sleep(wait_time)
+
+    sw('killall tcpdump'.format(**locals()),
+        shell='bash_swns')
+
+    capture = sw('cat /tmp/interface.cap'.format(**locals()),
+                 shell='bash_swns')
+
+    sw('rm /tmp/interface.cap'.format(**locals()),
+       shell='bash_swns')
+
+    return capture
+
+
+def get_info_from_packet_capture(capture, switch_side, sw_mac):
+    packet_re = (r'[\s \S]*' + sw_mac.lower() + '\s\>\s' + LACP_MAC_HEADER +
+                 r'\,[\s \S]*'
+                 r'' + switch_side + '\sInformation\sTLV\s\(0x\d*\)'
+                 r'\,\slength\s\d*\s*'
+                 r'System\s(?P<system_id>([0-9A-Fa-f]{2}[:-]){5}'
+                 r'[0-9A-Fa-f]{2})\,\s'
+                 r'System\sPriority\s(?P<system_priority>\d*)\,\s'
+                 r'Key\s(?P<key>\d*)\,\s'
+                 r'Port\s(?P<port_id>\d*)\,\s'
+                 r'Port\sPriority\s(?P<port_priority>\d*)')
+
+    re_result = re.search(packet_re, capture)
+    assert re_result
+
+    result = re_result.groupdict()
+
+    return result
+
+
+def tcpdump_capture_interface_start(sw, interface_id):
+    cmd_output = sw('tcpdump -D'.format(**locals()),
+                    shell='bash_swns')
+    interface_re = (r'(?P<linux_interface>\d)\.' + interface_id +
+                    r'\s[\[Up, Running\]]')
+    re_result = re.search(interface_re, cmd_output)
+    assert re_result
+    result = re_result.groupdict()
+
+    cmd_output = sw(
+        'tcpdump -ni ' + result['linux_interface'] +
+        ' -e ether proto ' + LACP_PROTOCOL + ' -vv'
+        '> /tmp/ops_{interface_id}.cap 2>&1 &'.format(**locals()),
+        shell='bash_swns'
+    )
+
+    res = re.compile(r'\[\d+\] (\d+)')
+    res_pid = res.findall(cmd_output)
+
+    if len(res_pid) == 1:
+        tcpdump_pid = int(res_pid[0])
+    else:
+        tcpdump_pid = -1
+
+    return tcpdump_pid
+
+
+def tcpdump_capture_interface_stop(sw, interface_id, tcpdump_pid):
+    sw('kill {tcpdump_pid}'.format(**locals()),
+        shell='bash_swns')
+
+    capture = sw('cat /tmp/ops_{interface_id}.cap'.format(**locals()),
+                 shell='bash_swns')
+
+    sw('rm /tmp/ops_{interface_id}.cap'.format(**locals()),
+       shell='bash_swns')
+
+    return capture
+
+
+def get_counters_from_packet_capture(capture):
+    tcp_counters = {}
+
+    packet_re = (r'(\d+) (\S+) (received|captured|dropped)')
+    res = re.compile(packet_re)
+    re_result = res.findall(capture)
+
+    for x in re_result:
+        tcp_counters[x[2]] = int(x[0])
+
+    return tcp_counters
+
+
+def set_debug(sw):
+    sw('ovs-appctl -t ops-lacpd vlog/set dbg'.format(**locals()),
+       shell='bash')
+
+
+def create_vlan(sw, vlan_id):
+    with sw.libs.vtysh.ConfigVlan(vlan_id) as ctx:
+        ctx.no_shutdown()
+
+
+def validate_vlan_state(sw, vlan_id, state):
+    output = sw.libs.vtysh.show_vlan(vlan_id)
+    assert output[vlan_id]['status'] == state,\
+        'Vlan is not in ' + state + ' state'
+
+
+def delete_vlan(sw, vlan):
+    with sw.libs.vtysh.Configure() as ctx:
+        ctx.no_vlan(vlan)
+    output = sw.libs.vtysh.show_vlan()
+    for vlan_index in output:
+        assert vlan != output[vlan_index]['vlan_id'],\
+            'Vlan was not deleted'
+
+
+def associate_vlan_to_l2_interface(
+    sw,
+    vlan_id,
+    interface,
+    vlan_type='access'
+):
+    port = find_device_label(sw, interface)
+    with sw.libs.vtysh.ConfigInterface(port) as ctx:
+        ctx.no_routing()
+        if vlan_type == 'access':
+            ctx.vlan_access(vlan_id)
+    output = sw.libs.vtysh.show_vlan(vlan_id)
+    assert interface in output[vlan_id]['ports'],\
+        'Vlan was not properly associated with Interface'
+
+
+def check_connectivity_between_hosts(h1, h1_ip, h2, h2_ip,
+                                     ping_num=5, success=True):
+    ping = h1.libs.ping.ping(ping_num, h2_ip)
+    if success:
+        # Assuming it is OK to lose 1 packet
+        assert ping['transmitted'] == ping_num <= ping['received'] + 1,\
+            'Ping between ' + h1_ip + ' and ' + h2_ip + ' failed'
+    else:
+        assert ping['received'] == 0,\
+            'Ping between ' + h1_ip + ' and ' + h2_ip + ' success'
+
+    ping = h2.libs.ping.ping(ping_num, h1_ip)
+    if success:
+        # Assuming it is OK to lose 1 packet
+        assert ping['transmitted'] == ping_num <= ping['received'] + 1,\
+            'Ping between ' + h2_ip + ' and ' + h1_ip + ' failed'
+    else:
+        assert ping['received'] == 0,\
+            'Ping between ' + h2_ip + ' and ' + h1_ip + ' success'
+
+
+def check_connectivity_between_switches(s1, s1_ip, s2, s2_ip,
+                                        ping_num=5, success=True):
+    ping = s1.libs.vtysh.ping_repetitions(s2_ip, ping_num)
+    if success:
+        assert ping['transmitted'] == ping['received'] == ping_num,\
+            'Ping between ' + s1_ip + ' and ' + s2_ip + ' failed'
+    else:
+        assert len(ping.keys()) == 0, \
+            'Ping between ' + s1_ip + ' and ' + s2_ip + ' success'
+
+    ping = s2.libs.vtysh.ping_repetitions(s1_ip, ping_num)
+    if success:
+        assert ping['transmitted'] == ping['received'] == ping_num,\
+            'Ping between ' + s2_ip + ' and ' + s1_ip + ' failed'
+    else:
+        assert len(ping.keys()) == 0,\
+            'Ping between ' + s2_ip + ' and ' + s1_ip + ' success'
+
+
+def is_interface_up(sw, interface):
+    interface_status = sw('show interface {interface}'.format(**locals()))
+    lines = interface_status.split('\n')
+    for line in lines:
+        if "Admin state" in line and "up" in line:
+            return True
+    return False
+
+
+def is_interface_down(sw, interface):
+    interface_status = sw('show interface {interface}'.format(**locals()))
+    lines = interface_status.split('\n')
+    for line in lines:
+        if "Admin state" in line and "up" not in line:
+            return True
+    return False
+
+def verify_vlan_full_state(sw, vlan_id, interfaces=None, status='up'):
+    vlan_status = sw.libs.vtysh.show_vlan()
+    vlan_str_id = str(vlan_id)
+    assert vlan_str_id in vlan_status,\
+        'VLAN not found, Expected: {}'.format(vlan_str_id)
+    assert vlan_status[vlan_str_id]['status'] == status,\
+        'Unexpected VLAN status, Expected: {}'.format(status)
+    if interfaces is None:
+        assert len(vlan_status[vlan_str_id]['ports']) == 0,\
+            ''.join(['Unexpected number of interfaces in VLAN',
+                     '{}, Expected: 0'.format(vlan_id)])
+    else:
+        assert len(vlan_status[vlan_str_id]['ports']) == len(interfaces),\
+            'Unexpected number of interfaces in VLAN {}, Expected: {}'.format(
+            vlan_id,
+            len(interfaces)
+        )
+        for interface in interfaces:
+            port = find_device_label(sw, interface)
+            assert port not in vlan_status[vlan_str_id],\
+                'Interface not found in VLAN {}, Expected {}'.format(
+                vlan_id,
+                port
+            )
+
+def retry_wrapper(
+    init_msg,
+    soft_err_msg,
+    time_steps,
+    timeout,
+    err_condition=None
+):
+    if err_condition is None:
+        err_condition = AssertionError
+
+    def actual_retry_wrapper(func):
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            print(init_msg)
+            cont = 0
+            while cont <= timeout:
+                try:
+                    func(*args, **kwargs)
+                    return
+                except err_condition:
+                    print(soft_err_msg)
+                    if cont < timeout:
+                        print('Waiting {} seconds to retry'.format(
+                            time_steps
+                        ))
+                        sleep(time_steps)
+                        cont += time_steps
+                        continue
+                    print('Retry time of {} seconds expired'.format(
+                        timeout
+                    ))
+                    raise
+        return wrapper
+    return actual_retry_wrapper
+
+
+def verify_turn_on_interfaces(sw, intf_list):
+    @retry_wrapper(
+        'Ensure interfaces are turn on',
+        'Interfaces not yet ready',
+        5,
+        60)
+    def check_interfaces(sw):
+        validate_turn_on_interfaces(sw, intf_list)
+    check_interfaces(sw)
+
+def verify_connectivity_between_hosts(h1, h1_ip, h2, h2_ip, success=True):
+    @retry_wrapper(
+        'Ensure connectivity between hosts',
+        'LAG not yet ready',
+        5,
+        40)
+    def check_ping(h1, h1_ip, h2, h2_ip, success):
+        check_connectivity_between_hosts(h1, h1_ip, h2, h2_ip, success=success)
+    check_ping(h1, h1_ip, h2, h2_ip, success=success)
+
+
+def verify_connectivity_between_switches(s1, s1_ip, s2, s2_ip, success=True):
+    @retry_wrapper(
+        'Ensure connectivity between switches',
+        'LAG not yet ready',
+        5,
+        40)
+    def check_ping(s1, s1_ip, s2, s2_ip, success):
+        check_connectivity_between_switches(s1, s1_ip, s2, s2_ip,
+                                            success=success)
+    check_ping(s1, s1_ip, s2, s2_ip, success=success)

--- a/ops-tests/feature/bgp/test_bgp_ft_basic_bgp_route_advertise.py
+++ b/ops-tests/feature/bgp/test_bgp_ft_basic_bgp_route_advertise.py
@@ -21,6 +21,7 @@ OpenSwitch Test for vlan related configurations.
 """
 
 from vtysh_utils import SwitchVtyshUtils
+from interface_utils import verify_turn_on_interfaces
 
 TOPOLOGY = """
 # +-------+
@@ -89,6 +90,15 @@ def configure_switch_ips(step):
 
         i += 1
 
+def verify_interface_on(step):
+    step("\n########## Verifying interface are up ########## \n")
+
+    for switch in switches:
+        ports = [switch.ports["if01"]]
+        verify_turn_on_interfaces(switch, ports)
+
+    step("\nExiting verify_interface_on\n")
+
 
 def verify_bgp_running(step):
     step("\n########## Verifying bgp processes.. ##########\n")
@@ -156,6 +166,7 @@ def test_bgp_ft_basic_bgp_route_advertise(topology, step):
     ops2.name = "ops2"
 
     configure_switch_ips(step)
+    verify_interface_on(step)
     verify_bgp_running(step)
     configure_bgp(step)
     verify_configs(step)

--- a/ops-tests/feature/bgp/test_bgp_ft_ip_extcommunity_list.py
+++ b/ops-tests/feature/bgp/test_bgp_ft_ip_extcommunity_list.py
@@ -22,6 +22,7 @@ OpenSwitch Test for vlan related configurations.
 
 from bgp_config import BgpConfig
 from vtysh_utils import SwitchVtyshUtils
+from interface_utils import verify_turn_on_interfaces
 
 TOPOLOGY = """
 # Nodes
@@ -52,8 +53,8 @@ def configure_switch_ips(step):
     step("\n########## Configuring switch IPs.. ##########\n")
 
     i = 0
+    bgp_router_id = ['9.0.0.1', '9.0.0.2', '10.0.0.2']
     for switch in switches:
-        bgp_cfg = bgpconfigarr[i]
 
         if switch.name == 'ops1':
             switch("configure terminal")
@@ -66,12 +67,23 @@ def configure_switch_ips(step):
         switch("configure terminal")
         switch("interface %s" % switch.ports["if01"])
         switch("no shutdown")
-        switch("ip address %s/%s" % (bgp_cfg.routerid,
+        switch("ip address %s/%s" % (bgp_router_id[i],
                                      default_pl))
         switch("end")
 
         i += 1
 
+def verify_interface_on(step):
+    step("\n########## Verifying interface are up ########## \n")
+
+    for switch in switches:
+        int1 = switch.ports["if01"]
+        if switch.name == "ops1":
+            int2 = switch.ports["if02"]
+            ports = [int1, int2]
+        else:
+            ports = [int1]
+        verify_turn_on_interfaces(switch, ports)
 
 def setup_bgp_config(step):
     global bgpconfigarr, bgp_config1, bgp_config2, bgp_config3
@@ -306,8 +318,9 @@ def test_bgp_ft_ip_extcommunity_list(topology, step):
     ops2.name = "ops2"
     ops3.name = "ops3"
 
-    setup_bgp_config(step)
     configure_switch_ips(step)
+    verify_interface_on(step)
+    setup_bgp_config(step)
     verify_bgp_running(step)
     apply_bgp_config(step)
     verify_bgp_configs(step)

--- a/ops-tests/feature/bgp/test_bgp_ft_ipv6_prefixlist.py
+++ b/ops-tests/feature/bgp/test_bgp_ft_ipv6_prefixlist.py
@@ -21,6 +21,7 @@ OpenSwitch Test for vlan related configurations.
 """
 
 from time import sleep
+from interface_utils import verify_turn_on_interfaces
 
 TOPOLOGY = """
 # +-------+
@@ -211,6 +212,26 @@ def configure(step, switch1, switch2):
      - Apply route-map to neighbor on SW1
     """
 
+    with switch1.libs.vtysh.ConfigInterface("if01") as ctx:
+        # Enabling interface 1 SW1.
+        step("Enabling interface1 on SW1")
+        ctx.no_shutdown()
+        # Assigning an IPv6 address on interface 1 of SW1
+        step("Configuring IPv6 address on link 1 SW1")
+        ctx.ipv6_address("%s/%s" % (ipv6_addr1, default_pl))
+
+    verify_turn_on_interfaces(switch1, [switch1.ports["if01"]])
+
+    with switch2.libs.vtysh.ConfigInterface("if01") as ctx:
+        # Enabling interface 1 SW2.
+        step("Enabling interface1 on SW1")
+        ctx.no_shutdown()
+        # Assigning an IPv6 address on interface 1 of SW2
+        step("Configuring IPv6 address on link 1 SW2")
+        ctx.ipv6_address("%s/%s" % (ipv6_addr2, default_pl))
+
+    verify_turn_on_interfaces(switch2, [switch2.ports["if01"]])
+
     # Configuring ipv6 prefix-list on switch 1
     step("Configuring ipv6 prefix configuration on SW1")
     configure_prefix_list(switch1, "BGP1_IN", "10", "deny",
@@ -246,14 +267,6 @@ def configure(step, switch1, switch2):
     configure_neighbor_rmap(switch1, as_num1, ipv6_addr2, as_num2,
                             "BGP1_IN", "in")
     sleep(5)
-
-    with switch1.libs.vtysh.ConfigInterface("if01") as ctx:
-        # Enabling interface 1 SW1.
-        step("Enabling interface1 on SW1")
-        ctx.no_shutdown()
-        # Assigning an IPv6 address on interface 1 of SW1
-        step("Configuring IPv6 address on link 1 SW1")
-        ctx.ipv6_address("%s/%s" % (ipv6_addr1, default_pl))
 
     # Configuring ipv6 prefix-list on switch 2
     step("Configuring ipv6 prefix list configuration on SW2")
@@ -312,14 +325,6 @@ def configure(step, switch1, switch2):
     configure_neighbor_rmap(switch2, as_num2, ipv6_addr1, as_num1,
                             "BGP2_Rmap2", "in")
     sleep(10)
-
-    with switch2.libs.vtysh.ConfigInterface("if01") as ctx:
-        # Enabling interface 1 SW2.
-        step("Enabling interface1 on SW1")
-        ctx.no_shutdown()
-        # Assigning an IPv6 address on interface 1 of SW2
-        step("Configuring IPv6 address on link 1 SW2")
-        ctx.ipv6_address("%s/%s" % (ipv6_addr2, default_pl))
 
 
 def test_bgp_ft_ipv6_prefixlist(topology, step):

--- a/ops-tests/feature/bgp/test_bgp_ft_neighbor_password.py
+++ b/ops-tests/feature/bgp/test_bgp_ft_neighbor_password.py
@@ -21,6 +21,7 @@ OpenSwitch Test for vlan related configurations.
 """
 
 from vtysh_utils import SwitchVtyshUtils
+from interface_utils import verify_turn_on_interfaces
 
 TOPOLOGY = """
 # +-------+
@@ -96,6 +97,14 @@ def configure_switch_ips(step):
 
         i += 1
 
+def verify_interface_on(step):
+    step("\n########## Verifying interface are up ########## \n")
+
+    for switch in switches:
+        ports = [switch.ports["if01"]]
+        verify_turn_on_interfaces(switch, ports)
+
+    step("\nExiting verify_interface_on\n")
 
 def configure_bgp(step):
     step("\n########## Configuring BGP on all switches.. ##########\n")
@@ -198,6 +207,7 @@ def test_bgp_ft_neighbor_password(topology, step):
     ops2.name = "ops2"
 
     configure_switch_ips(step)
+    verify_interface_on(step)
     configure_bgp(step)
     verify_neighbor_password(step)
     verify_incorrect_password(step)

--- a/ops-tests/feature/bgp/test_bgp_ft_neighbor_remove_private_as.py
+++ b/ops-tests/feature/bgp/test_bgp_ft_neighbor_remove_private_as.py
@@ -21,7 +21,7 @@ OpenSwitch Test for vlan related configurations.
 """
 
 from vtysh_utils import SwitchVtyshUtils
-
+from interface_utils import verify_turn_on_interfaces
 
 TOPOLOGY = """
 # +-------+
@@ -117,6 +117,15 @@ def configure_switch_ips(step):
             switch("end")
 
         i += 1
+
+def verify_interface_on(step):
+    step("\n########## Verifying interface are up ########## \n")
+
+    for switch in switches:
+        ports = [switch.ports["if01"]]
+        verify_turn_on_interfaces(switch, ports)
+
+    step("\nExiting verify_interface_on\n")
 
 
 def verify_bgp_running(step):
@@ -261,6 +270,7 @@ def test_bgp_ft_neighbor_remove_private_as(topology, step):
     ops3.name = "ops3"
 
     configure_switch_ips(step)
+    verify_interface_on(step)
     verify_bgp_running(step)
     configure_bgp(step)
     verify_neighbor_remove_private_as(step)

--- a/ops-tests/feature/bgp/test_bgp_ft_no_neighbor.py
+++ b/ops-tests/feature/bgp/test_bgp_ft_no_neighbor.py
@@ -21,6 +21,7 @@ OpenSwitch Test for vlan related configurations.
 """
 
 from vtysh_utils import SwitchVtyshUtils
+from interface_utils import verify_turn_on_interfaces
 
 TOPOLOGY = """
 # +-------+
@@ -89,6 +90,14 @@ def configure_switch_ips(step):
 
         i += 1
 
+def verify_interface_on(step):
+    step("\n########## Verifying interface are up ########## \n")
+
+    for switch in switches:
+        ports = [switch.ports["if01"]]
+        verify_turn_on_interfaces(switch, ports)
+
+    step("\nExiting verify_interface_on\n")
 
 def verify_bgp_running(step):
     step("\n########## Verifying bgp processes.. ##########\n")
@@ -170,6 +179,7 @@ def test_bgp_ft_no_neighbor(topology, step):
     ops2.name = "ops2"
 
     configure_switch_ips(step)
+    verify_interface_on(step)
     verify_bgp_running(step)
     configure_bgp(step)
     verify_bgp_routes(step)

--- a/ops-tests/feature/bgp/test_bgp_ft_peergroup.py
+++ b/ops-tests/feature/bgp/test_bgp_ft_peergroup.py
@@ -21,6 +21,7 @@ OpenSwitch Test for vlan related configurations.
 """
 
 from vtysh_utils import SwitchVtyshUtils
+from interface_utils import verify_turn_on_interfaces
 
 TOPOLOGY = """
 # +-------+
@@ -97,6 +98,14 @@ def configure_switch_ips(step):
 
         i += 1
 
+def verify_interface_on(step):
+    step("\n########## Verifying interface are up ########## \n")
+
+    for switch in switches:
+        ports = [switch.ports["if01"]]
+        verify_turn_on_interfaces(switch, ports)
+
+    step("\nExiting verify_interface_on\n")
 
 def verify_bgp_running(step):
     step("\n########## Verifying bgp processes.. ##########\n")
@@ -217,6 +226,7 @@ def test_bgp_ft_peergroup(topology, step):
     ops2.name = "ops2"
 
     configure_switch_ips(step)
+    verify_interface_on(step)
     verify_bgp_running(step)
     configure_bgp(step)
     verify_configs(step)

--- a/ops-tests/feature/bgp/test_bgp_ft_redistribute.py
+++ b/ops-tests/feature/bgp/test_bgp_ft_redistribute.py
@@ -22,6 +22,7 @@ OpenSwitch Test for vlan related configurations.
 
 from time import sleep
 from pytest import mark
+from interface_utils import verify_turn_on_interfaces
 
 TOPOLOGY = """
 # Nodes
@@ -179,6 +180,8 @@ def configure(step, switch1, switch2, switch3):
         step("Configuring IPv4 address on link 1 SW1")
         ctx.ip_address("%s/%s" % (ip_addr1, default_pl))
 
+    verify_turn_on_interfaces(switch1, [switch1.ports["if01"]])
+
     with switch2.libs.vtysh.ConfigInterface("if01") as ctx:
         # Enabling interface 1 SW2.
         step("Enabling interface1 on SW2")
@@ -195,6 +198,9 @@ def configure(step, switch1, switch2, switch3):
         step("Configuring IPv4 address on link 2 SW2")
         ctx.ip_address("%s/%s" % (ip_addr3, default_pl))
 
+    ports = [switch2.ports["if01"], switch2.ports["if02"]]
+    verify_turn_on_interfaces(switch2, ports)
+
     with switch3.libs.vtysh.ConfigInterface("if01") as ctx:
         # Enabling interface 1 SW3.
         step("Enabling interface1 on SW3")
@@ -202,6 +208,8 @@ def configure(step, switch1, switch2, switch3):
         # Assigning an IPv4 address on interface 1 of SW3
         step("Configuring IPv4 address on link 1 SW3")
         ctx.ip_address("%s/%s" % (ip_addr4, default_pl))
+
+    verify_turn_on_interfaces(switch3, [switch3.ports["if01"]])
 
     """
     For SW2 and SW3, configure bgp

--- a/ops-tests/feature/bgp/test_bgp_ft_routemap.py
+++ b/ops-tests/feature/bgp/test_bgp_ft_routemap.py
@@ -22,6 +22,7 @@ OpenSwitch Test for vlan related configurations.
 
 from bgp_config import BgpConfig, PrefixList
 from vtysh_utils import SwitchVtyshUtils
+from interface_utils import verify_turn_on_interfaces
 
 TOPOLOGY = """
 # +-------+
@@ -73,6 +74,12 @@ def configure_switch_ips(step):
 
         i += 1
 
+def verify_interface_on(step):
+    step("\n########## Verifying interface are up ########## \n")
+
+    for switch in switches:
+        ports = [switch.ports["if01"]]
+        verify_turn_on_interfaces(switch, ports)
 
 def setup_bgp_config(step):
     global bgpconfigarr, bgp_config1, bgp_config2
@@ -479,6 +486,7 @@ def test_bgp_ft_routemap(topology, step):
 
     setup_bgp_config(step)
     configure_switch_ips(step)
+    verify_interface_on(step)
     verify_bgp_running(step)
     apply_bgp_config(step)
     verify_bgp_configs(step)

--- a/ops-tests/feature/bgp/test_bgp_ft_routemap_aspath.py
+++ b/ops-tests/feature/bgp/test_bgp_ft_routemap_aspath.py
@@ -22,6 +22,7 @@ OpenSwitch Test for vlan related configurations.
 
 from pytest import mark
 from time import sleep
+from interface_utils import verify_turn_on_interfaces
 
 TOPOLOGY = """
 # +-------+
@@ -187,6 +188,8 @@ def configure(step, switch1, switch2):
         step("Configuring IPv4 address on link 1 SW1")
         ctx.ip_address("%s/%s" % (ip_addr1, default_pl))
 
+    verify_turn_on_interfaces(switch1, [switch1.ports["if01"]])
+
     with switch2.libs.vtysh.ConfigInterface("if01") as ctx:
         # Enabling interface 1 SW2.
         step("Enabling interface1 on SW2")
@@ -194,6 +197,8 @@ def configure(step, switch1, switch2):
         # Assigning an IPv4 address on interface 1 of SW2
         step("Configuring IPv4 address on link 1 SW2")
         ctx.ip_address("%s/%s" % (ip_addr2, default_pl))
+
+    verify_turn_on_interfaces(switch2, [switch2.ports["if01"]])
 
     # For SW1 and SW2, configure bgp
     step("Configuring router id on SW1")

--- a/ops-tests/feature/bgp/test_bgp_ft_routemap_atomic_aggregate.py
+++ b/ops-tests/feature/bgp/test_bgp_ft_routemap_atomic_aggregate.py
@@ -19,6 +19,7 @@
 
 from time import sleep
 from pytest import mark
+from interface_utils import verify_turn_on_interfaces
 
 
 TOPOLOGY = """
@@ -295,6 +296,8 @@ def configure(switch1, switch2, step):
         step("Configuring IPv4 address on link 1 SW1")
         ctx.ip_address("%s/%s" % (ip_addr1, default_pl))
 
+    verify_turn_on_interfaces(switch1, [switch1.ports["if01"]])
+
     with switch2.libs.vtysh.ConfigInterface("if01") as ctx:
         # Enabling interface 1 SW2.
         step("Enabling interface1 on SW2")
@@ -302,6 +305,8 @@ def configure(switch1, switch2, step):
         # Assigning an IPv4 address on interface 1 of SW2
         step("Configuring IPv4 address on link 1 SW2")
         ctx.ip_address("%s/%s" % (ip_addr2, default_pl))
+
+    verify_turn_on_interfaces(switch2, [switch2.ports["if01"]])
 
 #    For SW1 and SW2, configure bgp
     step("Configuring router id on SW1")

--- a/ops-tests/feature/bgp/test_bgp_ft_routemap_ipv6_next_hop.py
+++ b/ops-tests/feature/bgp/test_bgp_ft_routemap_ipv6_next_hop.py
@@ -22,6 +22,7 @@ OpenSwitch Test for vlan related configurations.
 
 from pytest import mark
 from time import sleep
+from interface_utils import verify_turn_on_interfaces
 
 TOPOLOGY = """
 # Nodes
@@ -192,6 +193,8 @@ def configure(step, switch1, switch2):
         # Assigning an IPv4 address on interface 1 of SW1
         ctx.ip_address("%s/8" % (sw1_router_id))
 
+    verify_turn_on_interfaces(switch1, [switch1.ports["if01"]])
+
     with switch2.libs.vtysh.ConfigInterface("if01") as ctx:
         # Enabling interface 1 SW2.
         step("Enabling interface1 on SW2")
@@ -201,6 +204,8 @@ def configure(step, switch1, switch2):
         ctx.ipv6_address("%s/64" % ip_addr2)
         # Assigning an IPv4 address on interface 1 for link 1 SW2
         ctx.ip_address("%s/8" % (sw2_router_id))
+
+    verify_turn_on_interfaces(switch2, [switch2.ports["if01"]])
 
     """
     For SW1 and SW2, configure bgp

--- a/ops-tests/feature/bgp/test_bgp_ft_routemap_metric.py
+++ b/ops-tests/feature/bgp/test_bgp_ft_routemap_metric.py
@@ -22,6 +22,7 @@ OpenSwitch Test for vlan related configurations.
 
 from time import sleep
 from pytest import mark
+from interface_utils import verify_turn_on_interfaces
 
 TOPOLOGY = """
 # +-------+
@@ -366,6 +367,8 @@ def configure(step, switch1, switch2):
         step("Configuring IPv4 address on link 1 SW1")
         ctx.ip_address("%s/%s" % (ip_addr1, default_pl))
 
+    verify_turn_on_interfaces(switch1, [switch1.ports["if01"]])
+
     with switch2.libs.vtysh.ConfigInterface("if01") as ctx:
         # Enabling interface 1 SW2.
         step("Enabling interface1 on SW2")
@@ -373,6 +376,8 @@ def configure(step, switch1, switch2):
         # Assigning an IPv4 address on interface 1 of SW2
         step("Configuring IPv4 address on link 1 SW2")
         ctx.ip_address("%s/%s" % (ip_addr2, default_pl))
+
+    verify_turn_on_interfaces(switch2, [switch2.ports["if01"]])
 
     step("Configuring router id on SW1")
     configure_router_id(switch1, as_num1, sw1_router_id)

--- a/ops-tests/feature/bgp/test_bgp_ft_routemap_metric_clear_all_in.py
+++ b/ops-tests/feature/bgp/test_bgp_ft_routemap_metric_clear_all_in.py
@@ -18,6 +18,7 @@
 
 
 from time import sleep
+from interface_utils import verify_turn_on_interfaces
 
 
 TOPOLOGY = """
@@ -329,6 +330,8 @@ def configure(topology, step):
         step("Configuring IPv4 address on link 1 SW1")
         ctx.ip_address("%s/%s" % (ip_addr1, default_pl))
 
+    verify_turn_on_interfaces(switch1, [switch1.ports["if01"]])
+
     with switch2.libs.vtysh.ConfigInterface("if01") as ctx:
         # Enabling interface 1 SW2.
         step("Enabling interface1 on SW2")
@@ -345,6 +348,9 @@ def configure(topology, step):
         step("Configuring IPv4 address on link 2 SW2")
         ctx.ip_address("%s/%s" % (ip_addr2_2, default_pl))
 
+    ports = [switch2.ports["if01"], switch2.ports["if02"]]
+    verify_turn_on_interfaces(switch2, ports)
+
     with switch3.libs.vtysh.ConfigInterface("if01") as ctx:
         # Enabling interface 1 SW3.
         step("Enabling interface1 on SW3")
@@ -352,6 +358,8 @@ def configure(topology, step):
         # Assigning an IPv4 address on interface 1 of SW3
         step("Configuring IPv4 address on link 1 SW3")
         ctx.ip_address("%s/%s" % (ip_addr3, default_pl))
+
+    verify_turn_on_interfaces(switch3, [switch3.ports["if01"]])
 
     # For SW1, SW2 and SW3, configure bgp
     step("Configuring router id on SW1")

--- a/ops-tests/feature/bgp/test_bgp_ft_routemap_metric_clear_all_out.py
+++ b/ops-tests/feature/bgp/test_bgp_ft_routemap_metric_clear_all_out.py
@@ -15,6 +15,7 @@
 
 from time import sleep
 import pytest
+from interface_utils import verify_turn_on_interfaces
 
 TOPOLOGY = """
 #
@@ -343,6 +344,8 @@ def configure(sw1, sw2, sw3):
     sw1("ip address %s/%s" % (IP_ADDR1, DEFAULT_PL))
     sw1("end")
 
+    verify_turn_on_interfaces(sw1, [sw1.ports["if01"]])
+
     # Enabling interface 1 SW2
     print("Enabling interface1 on SW2")
     sw2p1 = sw2.ports['if01']
@@ -367,6 +370,9 @@ def configure(sw1, sw2, sw3):
     sw2("ip address %s/%s" % (IP_ADDR2_2, DEFAULT_PL))
     sw2("end")
 
+    ports = [sw2.ports["if01"], sw2.ports["if02"]]
+    verify_turn_on_interfaces(sw2, ports)
+
     # Enabling interface 1 SW3
     print("Enabling interface 1 on SW3")
     sw3p1 = sw3.ports['if01']
@@ -378,6 +384,8 @@ def configure(sw1, sw2, sw3):
     print("Configuring IPv4 address on link 2 SW3")
     sw3("ip address %s/%s" % (IP_ADDR3, DEFAULT_PL))
     sw3("end")
+
+    verify_turn_on_interfaces(sw3, [sw3.ports["if01"]])
 
     # For SW1, SW2 and SW3, configure bgp
     print("Configuring route context on SW1")

--- a/ops-tests/feature/bgp/test_bgp_ft_routemap_metric_clear_as_in.py
+++ b/ops-tests/feature/bgp/test_bgp_ft_routemap_metric_clear_as_in.py
@@ -15,6 +15,7 @@
 
 from time import sleep
 import pytest
+from interface_utils import verify_turn_on_interfaces
 
 TOPOLOGY = """
 #
@@ -287,6 +288,8 @@ def configure(sw1, sw2, sw3):
     sw1("ip address %s/%s" % (IP_ADDR1, DEFAULT_PL))
     sw1("end")
 
+    verify_turn_on_interfaces(sw1, [sw1.ports["if01"]])
+
     # Enabling interface 1 SW2
     print("Enabling interface1 on SW2")
     sw2p1 = sw2.ports['if01']
@@ -311,6 +314,9 @@ def configure(sw1, sw2, sw3):
     sw2("ip address %s/%s" % (IP_ADDR2_2, DEFAULT_PL))
     sw2("end")
 
+    ports = [sw2.ports["if01"], sw2.ports["if02"]]
+    verify_turn_on_interfaces(sw2, ports)
+
     # Enabling interface 1 SW3
     print("Enabling interface 1 on SW3")
     sw3p1 = sw3.ports['if01']
@@ -322,6 +328,8 @@ def configure(sw1, sw2, sw3):
     print("Configuring IPv4 address on link 2 SW3")
     sw3("ip address %s/%s" % (IP_ADDR3, DEFAULT_PL))
     sw3("end")
+
+    verify_turn_on_interfaces(sw3, [sw3.ports["if01"]])
 
     # For SW1, SW2 and SW3, configure bgp
     print("Configuring route context on SW1")

--- a/ops-tests/feature/bgp/test_bgp_ft_routemap_metric_clear_as_out.py
+++ b/ops-tests/feature/bgp/test_bgp_ft_routemap_metric_clear_as_out.py
@@ -15,6 +15,7 @@
 
 from time import sleep
 import pytest
+from interface_utils import verify_turn_on_interfaces
 
 TOPOLOGY = """
 #
@@ -295,6 +296,8 @@ def configure(sw1, sw2, sw3):
     sw1("ip address %s/%s" % (IP_ADDR1, DEFAULT_PL))
     sw1("end")
 
+    verify_turn_on_interfaces(sw1, [sw1.ports["if01"]])
+
     # Enabling interface 1 SW2
     print("Enabling interface1 on SW2")
     sw2p1 = sw2.ports['if01']
@@ -319,6 +322,9 @@ def configure(sw1, sw2, sw3):
     sw2("ip address %s/%s" % (IP_ADDR2_2, DEFAULT_PL))
     sw2("end")
 
+    ports = [sw2.ports["if01"], sw2.ports["if02"]]
+    verify_turn_on_interfaces(sw2, ports)
+
     # Enabling interface 1 SW3
     print("Enabling interface 1 on SW3")
     sw3p1 = sw3.ports['if01']
@@ -330,6 +336,8 @@ def configure(sw1, sw2, sw3):
     print("Configuring IPv4 address on link 2 SW3")
     sw3("ip address %s/%s" % (IP_ADDR3, DEFAULT_PL))
     sw3("end")
+
+    verify_turn_on_interfaces(sw3, [sw3.ports["if01"]])
 
     # For SW1, SW2 and SW3, configure bgp
     print("Configuring route context on SW1")

--- a/ops-tests/feature/bgp/test_bgp_ft_routemap_metric_clear_peer_group_in.py
+++ b/ops-tests/feature/bgp/test_bgp_ft_routemap_metric_clear_peer_group_in.py
@@ -22,6 +22,7 @@ OpenSwitch Test for vlan related configurations.
 
 from time import sleep
 from pytest import mark
+from interface_utils import verify_turn_on_interfaces
 
 TOPOLOGY = """
 # +-------+
@@ -290,6 +291,8 @@ def configure(step, switch1, switch2, switch3):
         # Assigning an IPv4 address on interface 1 of SW1
         ctx.ip_address("%s/%s" % (IP_ADDR1, DEFAULT_PL))
 
+    verify_turn_on_interfaces(switch1, [switch1.ports["if01"]])
+
     with switch2.libs.vtysh.ConfigInterface("if01") as ctx:
         # Enabling interface 1 SW2.
         step("Enabling interface1 on SW2")
@@ -304,12 +307,17 @@ def configure(step, switch1, switch2, switch3):
         # Assigning an IPv4 address on interface 2 of SW2
         ctx.ip_address("%s/%s" % (IP_ADDR2_2, DEFAULT_PL))
 
+    ports = [switch2.ports["if01"], switch2.ports["if02"]]
+    verify_turn_on_interfaces(switch2, ports)
+
     with switch3.libs.vtysh.ConfigInterface("if01") as ctx:
         # Enabling interface 1 SW3.
         step("Enabling interface1 on SW3")
         ctx.no_shutdown()
         # Assigning an IPv4 address on interface 1 of SW3
         ctx.ip_address("%s/%s" % (IP_ADDR3, DEFAULT_PL))
+
+    verify_turn_on_interfaces(switch3, [switch3.ports["if01"]])
 
 #   For SW1, SW2 and SW3, configure bgp
     step("Configuring router id on SW1")

--- a/ops-tests/feature/bgp/test_bgp_ft_routemap_metric_clear_peer_group_out.py
+++ b/ops-tests/feature/bgp/test_bgp_ft_routemap_metric_clear_peer_group_out.py
@@ -22,6 +22,7 @@ OpenSwitch Test for vlan related configurations.
 
 from time import sleep
 from pytest import mark
+from interface_utils import verify_turn_on_interfaces
 
 TOPOLOGY = """
 # +-------+
@@ -293,6 +294,8 @@ def configure(step, switch1, switch2, switch3):
         # Assigning an IPv4 address on interface 1 of SW1
         ctx.ip_address("%s/%s" % (IP_ADDR1, DEFAULT_PL))
 
+    verify_turn_on_interfaces(switch1, [switch1.ports["if01"]])
+
     with switch2.libs.vtysh.ConfigInterface("if01") as ctx:
         # Enabling interface 1 SW2.
         step("Enabling interface1 on SW2")
@@ -307,12 +310,17 @@ def configure(step, switch1, switch2, switch3):
         # Assigning an IPv4 address on interface 2 of SW2
         ctx.ip_address("%s/%s" % (IP_ADDR2_2, DEFAULT_PL))
 
+    ports = [switch2.ports["if01"], switch2.ports["if02"]]
+    verify_turn_on_interfaces(switch2, ports)
+
     with switch3.libs.vtysh.ConfigInterface("if01") as ctx:
         # Enabling interface 1 SW3.
         step("Enabling interface1 on SW3")
         ctx.no_shutdown()
         # Assigning an IPv4 address on interface 1 of SW3
         ctx.ip_address("%s/%s" % (IP_ADDR3, DEFAULT_PL))
+
+    verify_turn_on_interfaces(switch3, [switch3.ports["if01"]])
 
 #   For SW1, SW2 and SW3, configure bgp
     step("Configuring router id on SW1")

--- a/ops-tests/feature/bgp/test_bgp_ft_routemap_metric_clear_peer_in.py
+++ b/ops-tests/feature/bgp/test_bgp_ft_routemap_metric_clear_peer_in.py
@@ -18,6 +18,7 @@
 
 
 from time import sleep
+from interface_utils import verify_turn_on_interfaces
 
 
 TOPOLOGY = """
@@ -329,6 +330,8 @@ def configure(topology, step):
         step("Configuring IPv4 address on link 1 SW1")
         ctx.ip_address("%s/%s" % (ip_addr1, default_pl))
 
+    verify_turn_on_interfaces(switch1, [switch1.ports["if01"]])
+
     with switch2.libs.vtysh.ConfigInterface("if01") as ctx:
         # Enabling interface 1 SW2.
         step("Enabling interface1 on SW2")
@@ -345,6 +348,9 @@ def configure(topology, step):
         step("Configuring IPv4 address on link 2 SW2")
         ctx.ip_address("%s/%s" % (ip_addr2_2, default_pl))
 
+    ports = [switch2.ports["if01"], switch2.ports["if02"]]
+    verify_turn_on_interfaces(switch2, ports)
+
     with switch3.libs.vtysh.ConfigInterface("if01") as ctx:
         # Enabling interface 1 SW3.
         step("Enabling interface1 on SW3")
@@ -352,6 +358,8 @@ def configure(topology, step):
         # Assigning an IPv4 address on interface 1 of SW3
         step("Configuring IPv4 address on link 1 SW3")
         ctx.ip_address("%s/%s" % (ip_addr3, default_pl))
+
+    verify_turn_on_interfaces(switch3, [switch3.ports["if01"]])
 
     # For SW1, SW2 and SW3, configure bgp
     step("Configuring router id on SW1")

--- a/ops-tests/feature/bgp/test_bgp_ft_routemap_metric_clear_peer_out.py
+++ b/ops-tests/feature/bgp/test_bgp_ft_routemap_metric_clear_peer_out.py
@@ -17,6 +17,7 @@
 ##########################################################################
 
 from time import sleep
+from interface_utils import verify_turn_on_interfaces
 
 
 TOPOLOGY = """
@@ -332,6 +333,8 @@ def configure(topology, step):
         step("Configuring IPv4 address on link 1 SW1")
         ctx.ip_address("%s/%s" % (ip_addr1, default_pl))
 
+    verify_turn_on_interfaces(switch1, [switch1.ports["if01"]])
+
     with switch2.libs.vtysh.ConfigInterface("if01") as ctx:
         # Enabling interface 1 SW2.
         step("Enabling interface1 on SW2")
@@ -348,6 +351,9 @@ def configure(topology, step):
         step("Configuring IPv4 address on link 2 SW2")
         ctx.ip_address("%s/%s" % (ip_addr2_2, default_pl))
 
+    ports = [switch2.ports["if01"], switch2.ports["if02"]]
+    verify_turn_on_interfaces(switch2, ports)
+
     with switch3.libs.vtysh.ConfigInterface("if01") as ctx:
         # Enabling interface 1 SW3.
         step("Enabling interface1 on SW3")
@@ -355,6 +361,8 @@ def configure(topology, step):
         # Assigning an IPv4 address on interface 1 of SW3
         step("Configuring IPv4 address on link 1 SW3")
         ctx.ip_address("%s/%s" % (ip_addr3, default_pl))
+
+    verify_turn_on_interfaces(switch3, [switch3.ports["if01"]])
 
     # For SW1, SW2 and SW3, configure bgp
     step("Configuring router id on SW1")

--- a/ops-tests/feature/bgp/test_bgp_ft_routemap_origin.py
+++ b/ops-tests/feature/bgp/test_bgp_ft_routemap_origin.py
@@ -22,6 +22,7 @@ OpenSwitch Test for vlan related configurations.
 
 from pytest import mark
 from time import sleep
+from interface_utils import verify_turn_on_interfaces
 
 TOPOLOGY = """
 # +-------+
@@ -198,6 +199,8 @@ def configure(step, switch1, switch2):
         step("Configuring IPv4 address on link 1 SW1")
         ctx.ip_address("%s/%s" % (ip_addr1, default_pl))
 
+    verify_turn_on_interfaces(switch1, [switch1.ports["if01"]])
+
     with switch2.libs.vtysh.ConfigInterface("if01") as ctx:
         # Enabling interface 1 SW2.
         step("Enabling interface1 on SW2")
@@ -205,6 +208,8 @@ def configure(step, switch1, switch2):
         # Assigning an IPv4 address on interface 1 of SW2
         step("Configuring IPv4 address on link 1 SW2")
         ctx.ip_address("%s/%s" % (ip_addr2, default_pl))
+
+    verify_turn_on_interfaces(switch2, [switch2.ports["if01"]])
 
     step("Configuring router id on SW1")
     configure_router_id(switch1, as_num1, sw1_router_id)

--- a/ops-tests/feature/bgp/test_bgp_ft_routemap_probability.py
+++ b/ops-tests/feature/bgp/test_bgp_ft_routemap_probability.py
@@ -22,6 +22,7 @@ OpenSwitch Test for vlan related configurations.
 
 from pytest import mark
 from time import sleep
+from interface_utils import verify_turn_on_interfaces
 
 TOPOLOGY = """
 # +-------+
@@ -226,6 +227,8 @@ def configure(step, switch1, switch2):
         step("Configuring IPv4 address on link 1 SW1")
         ctx.ip_address("%s/%s" % (ip_addr1, default_pl))
 
+    verify_turn_on_interfaces(switch1, [switch1.ports["if01"]])
+
     with switch2.libs.vtysh.ConfigInterface("if01") as ctx:
         # Enabling interface 1 SW2.
         step("Enabling interface1 on SW2")
@@ -233,6 +236,8 @@ def configure(step, switch1, switch2):
         # Assigning an IPv4 address on interface 1 of SW2
         step("Configuring IPv4 address on link 1 SW2")
         ctx.ip_address("%s/%s" % (ip_addr2, default_pl))
+
+    verify_turn_on_interfaces(switch2, [switch2.ports["if01"]])
 
     # For SW1 and SW2, configure bgp
     step("Configuring router id on SW1")

--- a/ops-tests/feature/bgp/test_bgp_ft_routemap_set_commlist.py
+++ b/ops-tests/feature/bgp/test_bgp_ft_routemap_set_commlist.py
@@ -22,6 +22,7 @@ OpenSwitch Test for vlan related configurations.
 
 from time import sleep
 from pytest import mark
+from interface_utils import verify_turn_on_interfaces
 
 TOPOLOGY = """
 # +-------+
@@ -281,12 +282,16 @@ def configure(step, switch1, switch2):
         # Assigning an IPv4 address on interface 1 of SW1
         ctx.ip_address("%s/%s" % (IP_ADDR1, DEFAULT_PL))
 
+    verify_turn_on_interfaces(switch1, [switch1.ports["if01"]])
+
     with switch2.libs.vtysh.ConfigInterface("if01") as ctx:
         # Enabling interface 1 SW2.
         step("Enabling interface1 on SW2")
         ctx.no_shutdown()
         # Assigning an IPv4 address on interface 1 of SW2
         ctx.ip_address("%s/%s" % (IP_ADDR2, DEFAULT_PL))
+
+    verify_turn_on_interfaces(switch2, [switch2.ports["if01"]])
 
 #    For SW1 and SW2, configure bgp
     step("Configuring router id on SW1")

--- a/ops-tests/feature/bgp/test_bgp_ft_routemap_weight.py
+++ b/ops-tests/feature/bgp/test_bgp_ft_routemap_weight.py
@@ -22,6 +22,7 @@ OpenSwitch Test for vlan related configurations.
 
 from time import sleep
 from pytest import mark
+from interface_utils import verify_turn_on_interfaces
 
 TOPOLOGY = """
 # +-------+
@@ -272,12 +273,16 @@ def configure(step, switch1, switch2):
         # Assigning an IPv4 address on interface 1 of SW1
         ctx.ip_address("%s/%s" % (IP_ADDR1, DEFAULT_PL))
 
+    verify_turn_on_interfaces(switch1, [switch1.ports["if01"]])
+
     with switch2.libs.vtysh.ConfigInterface("if01") as ctx:
         # Enabling interface 1 SW2.
         step("Enabling interface1 on SW2")
         ctx.no_shutdown()
         # Assigning an IPv4 address on interface 1 of SW2
         ctx.ip_address("%s/%s" % (IP_ADDR2, DEFAULT_PL))
+
+    verify_turn_on_interfaces(switch2, [switch2.ports["if01"]])
 
 #    For SW1 and SW2, configure bgp
     step("Configuring router id on SW1")

--- a/ops-tests/feature/bgp/test_bgp_ft_routemaps_with_hosts_ping.py
+++ b/ops-tests/feature/bgp/test_bgp_ft_routemaps_with_hosts_ping.py
@@ -21,6 +21,7 @@ OpenSwitch Test for vlan related configurations.
 """
 
 from vtysh_utils import SwitchVtyshUtils
+from interface_utils import verify_turn_on_interfaces
 
 TOPOLOGY = """
 # Nodes
@@ -160,6 +161,12 @@ def configure_switch_ips(step):
 
         i += 1
 
+def verify_interface_on(step):
+    step("\n########## Verifying interface are up ########## \n")
+
+    for switch in switches:
+        ports = [switch.ports["if01"], switch.ports["if02"]]
+        verify_turn_on_interfaces(switch, ports)
 
 def verify_bgp_running(step):
     step("\n########## Verifying bgp processes.. ##########\n")
@@ -294,6 +301,7 @@ def test_bgp_ft_routemaps_with_hosts_ping(topology, step):
     hs2.name = "hs2"
 
     configure_switch_ips(step)
+    verify_interface_on(step)
     verify_bgp_running(step)
     verify_hosts_ping_fail(step)
     configure_bgp(step)

--- a/ops-tests/feature/ospf/interface_utils.py
+++ b/ops-tests/feature/ospf/interface_utils.py
@@ -1,0 +1,377 @@
+# (C) Copyright 2016 Hewlett Packard Enterprise Development LP
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+#
+
+
+"""
+OpenSwitch Test Utility for BGP
+"""
+
+# from pytest import set_trace
+import re
+from time import sleep
+from functools import wraps
+
+def find_device_label(sw, interface):
+    assert interface in sw.ports.values()
+    for key, value in sw.ports.items():
+        if value == interface:
+            return key
+
+def turn_on_interface(sw, interface):
+    port = find_device_label(sw, interface)
+    with sw.libs.vtysh.ConfigInterface(port) as ctx:
+        ctx.no_shutdown()
+
+
+def turn_off_interface(sw, interface):
+    port = find_device_label(sw, interface)
+    with sw.libs.vtysh.ConfigInterface(port) as ctx:
+        ctx.shutdown()
+
+
+def validate_turn_on_interfaces(sw, interfaces):
+    for intf in interfaces:
+        port = find_device_label(sw, intf)
+        output = sw.libs.vtysh.show_interface(port)
+        assert output['interface_state'] == 'up',\
+            "Interface state for " + intf + " is down"
+
+
+def validate_turn_off_interfaces(sw, interfaces):
+    for intf in interfaces:
+        port = find_device_label(sw, intf)
+        output = sw.libs.vtysh.show_interface(port)
+        assert output['interface_state'] == 'down',\
+            "Interface state for " + port + "is up"
+
+
+def verify_turn_off_interfaces(sw, intf_list):
+    @retry_wrapper(
+        'Ensure interfaces are turn off',
+        'Interfaces not yet ready',
+        5,
+        60)
+    def check_interfaces(sw):
+        validate_turn_off_interfaces(sw, intf_list)
+    check_interfaces(sw)
+
+def get_device_mac_address(sw, interface):
+    cmd_output = sw('ifconfig'.format(**locals()),
+                    shell='bash_swns')
+    mac_re = (r'' + interface + '\s*Link\sencap:Ethernet\s*HWaddr\s'
+              r'(?P<mac_address>([0-9A-Fa-f]{2}[:-]){5}'
+              r'[0-9A-Fa-f]{2})')
+
+    re_result = re.search(mac_re, cmd_output)
+    assert re_result
+
+    result = re_result.groupdict()
+    print(result)
+
+    return result['mac_address']
+
+
+def tcpdump_capture_interface(sw, interface_id, wait_time):
+    cmd_output = sw('tcpdump -D'.format(**locals()),
+                    shell='bash_swns')
+    interface_re = (r'(?P<linux_interface>\d)\.' + interface_id +
+                    r'\s[\[Up, Running\]]')
+    re_result = re.search(interface_re, cmd_output)
+    assert re_result
+    result = re_result.groupdict()
+
+    sw('tcpdump -ni ' + result['linux_interface'] +
+        ' -e ether proto ' + LACP_PROTOCOL + ' -vv'
+        '> /tmp/interface.cap 2>&1 &'.format(**locals()),
+        shell='bash_swns')
+
+    sleep(wait_time)
+
+    sw('killall tcpdump'.format(**locals()),
+        shell='bash_swns')
+
+    capture = sw('cat /tmp/interface.cap'.format(**locals()),
+                 shell='bash_swns')
+
+    sw('rm /tmp/interface.cap'.format(**locals()),
+       shell='bash_swns')
+
+    return capture
+
+
+def get_info_from_packet_capture(capture, switch_side, sw_mac):
+    packet_re = (r'[\s \S]*' + sw_mac.lower() + '\s\>\s' + LACP_MAC_HEADER +
+                 r'\,[\s \S]*'
+                 r'' + switch_side + '\sInformation\sTLV\s\(0x\d*\)'
+                 r'\,\slength\s\d*\s*'
+                 r'System\s(?P<system_id>([0-9A-Fa-f]{2}[:-]){5}'
+                 r'[0-9A-Fa-f]{2})\,\s'
+                 r'System\sPriority\s(?P<system_priority>\d*)\,\s'
+                 r'Key\s(?P<key>\d*)\,\s'
+                 r'Port\s(?P<port_id>\d*)\,\s'
+                 r'Port\sPriority\s(?P<port_priority>\d*)')
+
+    re_result = re.search(packet_re, capture)
+    assert re_result
+
+    result = re_result.groupdict()
+
+    return result
+
+
+def tcpdump_capture_interface_start(sw, interface_id):
+    cmd_output = sw('tcpdump -D'.format(**locals()),
+                    shell='bash_swns')
+    interface_re = (r'(?P<linux_interface>\d)\.' + interface_id +
+                    r'\s[\[Up, Running\]]')
+    re_result = re.search(interface_re, cmd_output)
+    assert re_result
+    result = re_result.groupdict()
+
+    cmd_output = sw(
+        'tcpdump -ni ' + result['linux_interface'] +
+        ' -e ether proto ' + LACP_PROTOCOL + ' -vv'
+        '> /tmp/ops_{interface_id}.cap 2>&1 &'.format(**locals()),
+        shell='bash_swns'
+    )
+
+    res = re.compile(r'\[\d+\] (\d+)')
+    res_pid = res.findall(cmd_output)
+
+    if len(res_pid) == 1:
+        tcpdump_pid = int(res_pid[0])
+    else:
+        tcpdump_pid = -1
+
+    return tcpdump_pid
+
+
+def tcpdump_capture_interface_stop(sw, interface_id, tcpdump_pid):
+    sw('kill {tcpdump_pid}'.format(**locals()),
+        shell='bash_swns')
+
+    capture = sw('cat /tmp/ops_{interface_id}.cap'.format(**locals()),
+                 shell='bash_swns')
+
+    sw('rm /tmp/ops_{interface_id}.cap'.format(**locals()),
+       shell='bash_swns')
+
+    return capture
+
+
+def get_counters_from_packet_capture(capture):
+    tcp_counters = {}
+
+    packet_re = (r'(\d+) (\S+) (received|captured|dropped)')
+    res = re.compile(packet_re)
+    re_result = res.findall(capture)
+
+    for x in re_result:
+        tcp_counters[x[2]] = int(x[0])
+
+    return tcp_counters
+
+
+def set_debug(sw):
+    sw('ovs-appctl -t ops-lacpd vlog/set dbg'.format(**locals()),
+       shell='bash')
+
+
+def create_vlan(sw, vlan_id):
+    with sw.libs.vtysh.ConfigVlan(vlan_id) as ctx:
+        ctx.no_shutdown()
+
+
+def validate_vlan_state(sw, vlan_id, state):
+    output = sw.libs.vtysh.show_vlan(vlan_id)
+    assert output[vlan_id]['status'] == state,\
+        'Vlan is not in ' + state + ' state'
+
+
+def delete_vlan(sw, vlan):
+    with sw.libs.vtysh.Configure() as ctx:
+        ctx.no_vlan(vlan)
+    output = sw.libs.vtysh.show_vlan()
+    for vlan_index in output:
+        assert vlan != output[vlan_index]['vlan_id'],\
+            'Vlan was not deleted'
+
+
+def associate_vlan_to_l2_interface(
+    sw,
+    vlan_id,
+    interface,
+    vlan_type='access'
+):
+    port = find_device_label(sw, interface)
+    with sw.libs.vtysh.ConfigInterface(port) as ctx:
+        ctx.no_routing()
+        if vlan_type == 'access':
+            ctx.vlan_access(vlan_id)
+    output = sw.libs.vtysh.show_vlan(vlan_id)
+    assert interface in output[vlan_id]['ports'],\
+        'Vlan was not properly associated with Interface'
+
+
+def check_connectivity_between_hosts(h1, h1_ip, h2, h2_ip,
+                                     ping_num=5, success=True):
+    ping = h1.libs.ping.ping(ping_num, h2_ip)
+    if success:
+        # Assuming it is OK to lose 1 packet
+        assert ping['transmitted'] == ping_num <= ping['received'] + 1,\
+            'Ping between ' + h1_ip + ' and ' + h2_ip + ' failed'
+    else:
+        assert ping['received'] == 0,\
+            'Ping between ' + h1_ip + ' and ' + h2_ip + ' success'
+
+    ping = h2.libs.ping.ping(ping_num, h1_ip)
+    if success:
+        # Assuming it is OK to lose 1 packet
+        assert ping['transmitted'] == ping_num <= ping['received'] + 1,\
+            'Ping between ' + h2_ip + ' and ' + h1_ip + ' failed'
+    else:
+        assert ping['received'] == 0,\
+            'Ping between ' + h2_ip + ' and ' + h1_ip + ' success'
+
+
+def check_connectivity_between_switches(s1, s1_ip, s2, s2_ip,
+                                        ping_num=5, success=True):
+    ping = s1.libs.vtysh.ping_repetitions(s2_ip, ping_num)
+    if success:
+        assert ping['transmitted'] == ping['received'] == ping_num,\
+            'Ping between ' + s1_ip + ' and ' + s2_ip + ' failed'
+    else:
+        assert len(ping.keys()) == 0, \
+            'Ping between ' + s1_ip + ' and ' + s2_ip + ' success'
+
+    ping = s2.libs.vtysh.ping_repetitions(s1_ip, ping_num)
+    if success:
+        assert ping['transmitted'] == ping['received'] == ping_num,\
+            'Ping between ' + s2_ip + ' and ' + s1_ip + ' failed'
+    else:
+        assert len(ping.keys()) == 0,\
+            'Ping between ' + s2_ip + ' and ' + s1_ip + ' success'
+
+
+def is_interface_up(sw, interface):
+    interface_status = sw('show interface {interface}'.format(**locals()))
+    lines = interface_status.split('\n')
+    for line in lines:
+        if "Admin state" in line and "up" in line:
+            return True
+    return False
+
+
+def is_interface_down(sw, interface):
+    interface_status = sw('show interface {interface}'.format(**locals()))
+    lines = interface_status.split('\n')
+    for line in lines:
+        if "Admin state" in line and "up" not in line:
+            return True
+    return False
+
+def verify_vlan_full_state(sw, vlan_id, interfaces=None, status='up'):
+    vlan_status = sw.libs.vtysh.show_vlan()
+    vlan_str_id = str(vlan_id)
+    assert vlan_str_id in vlan_status,\
+        'VLAN not found, Expected: {}'.format(vlan_str_id)
+    assert vlan_status[vlan_str_id]['status'] == status,\
+        'Unexpected VLAN status, Expected: {}'.format(status)
+    if interfaces is None:
+        assert len(vlan_status[vlan_str_id]['ports']) == 0,\
+            ''.join(['Unexpected number of interfaces in VLAN',
+                     '{}, Expected: 0'.format(vlan_id)])
+    else:
+        assert len(vlan_status[vlan_str_id]['ports']) == len(interfaces),\
+            'Unexpected number of interfaces in VLAN {}, Expected: {}'.format(
+            vlan_id,
+            len(interfaces)
+        )
+        for interface in interfaces:
+            port = find_device_label(sw, interface)
+            assert port not in vlan_status[vlan_str_id],\
+                'Interface not found in VLAN {}, Expected {}'.format(
+                vlan_id,
+                port
+            )
+
+def retry_wrapper(
+    init_msg,
+    soft_err_msg,
+    time_steps,
+    timeout,
+    err_condition=None
+):
+    if err_condition is None:
+        err_condition = AssertionError
+
+    def actual_retry_wrapper(func):
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            print(init_msg)
+            cont = 0
+            while cont <= timeout:
+                try:
+                    func(*args, **kwargs)
+                    return
+                except err_condition:
+                    print(soft_err_msg)
+                    if cont < timeout:
+                        print('Waiting {} seconds to retry'.format(
+                            time_steps
+                        ))
+                        sleep(time_steps)
+                        cont += time_steps
+                        continue
+                    print('Retry time of {} seconds expired'.format(
+                        timeout
+                    ))
+                    raise
+        return wrapper
+    return actual_retry_wrapper
+
+
+def verify_turn_on_interfaces(sw, intf_list):
+    @retry_wrapper(
+        'Ensure interfaces are turn on',
+        'Interfaces not yet ready',
+        5,
+        60)
+    def check_interfaces(sw):
+        validate_turn_on_interfaces(sw, intf_list)
+    check_interfaces(sw)
+
+def verify_connectivity_between_hosts(h1, h1_ip, h2, h2_ip, success=True):
+    @retry_wrapper(
+        'Ensure connectivity between hosts',
+        'LAG not yet ready',
+        5,
+        40)
+    def check_ping(h1, h1_ip, h2, h2_ip, success):
+        check_connectivity_between_hosts(h1, h1_ip, h2, h2_ip, success=success)
+    check_ping(h1, h1_ip, h2, h2_ip, success=success)
+
+
+def verify_connectivity_between_switches(s1, s1_ip, s2, s2_ip, success=True):
+    @retry_wrapper(
+        'Ensure connectivity between switches',
+        'LAG not yet ready',
+        5,
+        40)
+    def check_ping(s1, s1_ip, s2, s2_ip, success):
+        check_connectivity_between_switches(s1, s1_ip, s2, s2_ip,
+                                            success=success)
+    check_ping(s1, s1_ip, s2, s2_ip, success=success)

--- a/ops-tests/feature/ospf/test_ospfv2_ft_abr.py
+++ b/ops-tests/feature/ospf/test_ospfv2_ft_abr.py
@@ -21,6 +21,7 @@ from ospf_configs import unconfigure_interface, unconfigure_ospf_router
 from ospf_configs import wait_for_adjacency, verify_route
 from ospf_configs import verify_router_type
 from pytest import fixture
+from interface_utils import verify_turn_on_interfaces
 
 TOPOLOGY = """
 #
@@ -102,6 +103,17 @@ def configuration(topology, request):
     configure_interface(sw3, SW3_INTF2, SW3_INTF2_IPV4_ADDR)
     configure_interface(sw4, SW4_INTF1, SW4_INTF1_IPV4_ADDR)
     configure_interface(sw5, SW5_INTF2, SW5_INTF2_IPV4_ADDR)
+
+    ports_sw1 = [sw1.ports[SW1_INTF1], sw1.ports[SW1_INTF2]]
+    verify_turn_on_interfaces(sw1, ports_sw1)
+    ports_sw2 = [sw2.ports[SW2_INTF1], sw2.ports[SW2_INTF2]]
+    verify_turn_on_interfaces(sw2, ports_sw2)
+    ports_sw3 = [sw3.ports[SW3_INTF1], sw3.ports[SW3_INTF2]]
+    verify_turn_on_interfaces(sw3, ports_sw3)
+    ports_sw4 = [sw4.ports[SW4_INTF1]]
+    verify_turn_on_interfaces(sw4, ports_sw4)
+    ports_sw5 = [sw5.ports[SW5_INTF2]]
+    verify_turn_on_interfaces(sw5, ports_sw5)
 
     # Configuring ospf with network command in sw1, sw2, sw3, sw4 and sw5
     configure_ospf_router(sw1, SW1_ROUTER_ID, SW1_INTF1_IPV4_ADDR,

--- a/ops-tests/feature/ospf/test_ospfv2_ft_authentication.py
+++ b/ops-tests/feature/ospf/test_ospfv2_ft_authentication.py
@@ -19,6 +19,7 @@ from ospf_configs import configure_interface, configure_ospf_router
 from ospf_configs import wait_for_adjacency
 from ospf_configs import unconfigure_interface, unconfigure_ospf_router
 from pytest import fixture
+from interface_utils import verify_turn_on_interfaces
 
 
 TOPOLOGY = """
@@ -64,6 +65,9 @@ def configuration(topology, request):
     # Configuring ip address for sw2 and sw3
     configure_interface(sw2, SW2_INTF2, SW2_INTF2_IPV4_ADDR)
     configure_interface(sw3, SW3_INTF2, SW3_INTF2_IPV4_ADDR)
+
+    verify_turn_on_interfaces(sw2, [sw2.ports[SW2_INTF2]])
+    verify_turn_on_interfaces(sw3, [sw3.ports[SW3_INTF2]])
 
     # Configuring ospf with network command in sw2 and sw3
     configure_ospf_router(sw2, SW2_ROUTER_ID, SW2_INTF2_IPV4_ADDR, OSPF_AREA_1)

--- a/ops-tests/feature/ospf/test_ospfv2_ft_best_route.py
+++ b/ops-tests/feature/ospf/test_ospfv2_ft_best_route.py
@@ -20,6 +20,7 @@ from ospf_configs import wait_for_adjacency, wait_for_route_distance
 from ospf_configs import unconfigure_interface, unconfigure_ospf_router
 from ospf_configs import wait_for_best_route, verify_ip_route
 from pytest import fixture
+from interface_utils import verify_turn_on_interfaces
 
 
 TOPOLOGY = """
@@ -71,6 +72,9 @@ def configuration(topology, request):
     # Configuring ip address for sw2 and sw3
     configure_interface(sw1, SW1_INTF1, SW1_INTF1_IPV4_ADDR)
     configure_interface(sw2, SW2_INTF1, SW2_INTF1_IPV4_ADDR)
+
+    verify_turn_on_interfaces(sw1, sw1.ports[SW1_INTF1])
+    verify_turn_on_interfaces(sw2, sw2.ports[SW2_INTF1])
 
     # Configuring ospf with network command in sw2 and sw3
     configure_ospf_router(sw1, SW1_ROUTER_ID, OSPF_NETWRK_ADDR, OSPF_AREA_1)

--- a/ops-tests/feature/ospf/test_ospfv2_ft_dr_bdr_election.py
+++ b/ops-tests/feature/ospf/test_ospfv2_ft_dr_bdr_election.py
@@ -19,6 +19,7 @@ from ospf_configs import configure_interface, configure_ospf_router
 from ospf_configs import wait_for_adjacency, verify_ospf_priority
 from ospf_configs import wait_for_2way_state, get_neighbor_state
 from pytest import fixture
+from interface_utils import verify_turn_on_interfaces
 
 TOPOLOGY = """
 #                         sw4(L2)
@@ -72,6 +73,10 @@ def configuration(topology, request):
     configure_interface(sw1, SW1_INTF1, SW1_INTF1_IPV4_ADDR)
     configure_interface(sw2, SW2_INTF1, SW2_INTF1_IPV4_ADDR)
     configure_interface(sw3, SW3_INTF1, SW3_INTF1_IPV4_ADDR)
+
+    verify_turn_on_interfaces(sw1, sw1.ports[SW1_INTF1])
+    verify_turn_on_interfaces(sw2, sw2.ports[SW2_INTF1])
+    verify_turn_on_interfaces(sw3, sw3.ports[SW3_INTF1])
 
     # Configuring ospf with network command in sw1, sw2 and sw3
     configure_ospf_router(sw1, SW1_ROUTER_ID, SW1_INTF1_IPV4_ADDR, OSPF_AREA_1)

--- a/ops-tests/feature/ospf/test_ospfv2_ft_ospf_disabled.py
+++ b/ops-tests/feature/ospf/test_ospfv2_ft_ospf_disabled.py
@@ -19,6 +19,7 @@ from ospf_configs import configure_interface, configure_ospf_router
 from ospf_configs import wait_for_adjacency
 from ospf_configs import unconfigure_interface, unconfigure_ospf_router
 from pytest import fixture
+from interface_utils import verify_turn_on_interfaces
 
 
 TOPOLOGY = """
@@ -71,6 +72,13 @@ def configuration(topology, request):
     configure_interface(sw2, SW2_INTF1, SW2_INTF1_IPV4_ADDR)
     configure_interface(sw2, SW2_INTF2, SW2_INTF2_IPV4_ADDR)
     configure_interface(sw3, SW3_INTF1, SW3_INTF1_IPV4_ADDR)
+
+    verify_turn_on_interfaces(sw1, [sw1.ports[SW1_INTF1]])
+
+    ports_sw2 = [sw2.ports[SW2_INTF1], sw2.ports[SW2_INTF2]]
+    verify_turn_on_interfaces(sw2, ports_sw2)
+
+    verify_turn_on_interfaces(sw3, [sw3.ports[SW3_INTF1]])
 
     # Configuring ospf with network command in sw1, sw2 and sw3
     configure_ospf_router(sw1, SW1_ROUTER_ID, SW1_INTF1_IPV4_ADDR, OSPF_AREA_1)

--- a/ops-tests/feature/ospf/test_ospfv2_ft_redistribution.py
+++ b/ops-tests/feature/ospf/test_ospfv2_ft_redistribution.py
@@ -22,6 +22,7 @@ from ospf_configs import configure_bgp_network
 from ospf_configs import unconfigure_ospf_network
 from ospf_configs import unconfigure_interface, unconfigure_ospf_router
 from pytest import fixture
+from pytest import mark
 
 
 TOPOLOGY = """
@@ -290,6 +291,7 @@ def test_ospf_redistribute_connected_routes(topology, configuration, step):
 
 # Test case [4.03] : Test case to verify
 # redistribution of bgp routes
+@mark.skipif(True, reason="Skipping the test temporarily as the test is failing")
 def test_ospf_redistribute_bgp_routes(topology, configuration, step):
 
     sw1 = topology.get('sw1')

--- a/ops-tests/feature/ospf/test_ospfv2_ft_redistribution.py
+++ b/ops-tests/feature/ospf/test_ospfv2_ft_redistribution.py
@@ -23,6 +23,7 @@ from ospf_configs import unconfigure_ospf_network
 from ospf_configs import unconfigure_interface, unconfigure_ospf_router
 from pytest import fixture
 from pytest import mark
+from interface_utils import verify_turn_on_interfaces
 
 
 TOPOLOGY = """
@@ -103,6 +104,13 @@ def configuration(topology, request):
     configure_interface(sw2, SW2_INTF2, SW2_INTF2_IPV4_ADDR)
     configure_interface(sw3, SW3_INTF1, SW3_INTF1_IPV4_ADDR)
     configure_interface(sw3, SW3_INTF2, SW3_INTF2_IPV4_ADDR)
+
+    ports_sw1 = [sw1.ports[SW1_INTF1], sw1.ports[SW1_INTF2]]
+    verify_turn_on_interfaces(sw1, ports_sw1)
+    ports_sw2 = [sw2.ports[SW2_INTF1], sw2.ports[SW2_INTF2]]
+    verify_turn_on_interfaces(sw2, ports_sw2)
+    ports_sw3 = [sw3.ports[SW3_INTF1], sw3.ports[SW3_INTF2]]
+    verify_turn_on_interfaces(sw3, ports_sw3)
 
     # Configure IP and bring UP host 1 interfaces
     hs1.libs.ip.interface('1', addr='10.10.40.2/24', up=True)
@@ -291,7 +299,6 @@ def test_ospf_redistribute_connected_routes(topology, configuration, step):
 
 # Test case [4.03] : Test case to verify
 # redistribution of bgp routes
-@mark.skipif(True, reason="Skipping the test temporarily as the test is failing")
 def test_ospf_redistribute_bgp_routes(topology, configuration, step):
 
     sw1 = topology.get('sw1')
@@ -345,7 +352,7 @@ def test_ospf_redistribute_bgp_routes(topology, configuration, step):
                           SW3_INTF1_IPV4_ADDR, SW3_NEIGHBOR, ASN_2)
 
     # Waiting for BGP routes to be updated in show rib command
-    time.sleep(10)
+    time.sleep(20)
     step('###### Verifying the redistributed BGP route '
          'in sw3 from sw1 ######')
     retval = verify_route(sw1, '10.10.30.0', '24')

--- a/ops-tests/feature/ospf/test_ospfv2_ft_stub.py
+++ b/ops-tests/feature/ospf/test_ospfv2_ft_stub.py
@@ -20,6 +20,7 @@ from ospf_configs import configure_interface, configure_ospf_router
 from ospf_configs import unconfigure_interface, unconfigure_ospf_router
 from ospf_configs import wait_for_adjacency, verify_route
 from pytest import fixture
+from interface_utils import verify_turn_on_interfaces
 
 TOPOLOGY = """
 #                       sw1(DUT)
@@ -72,6 +73,11 @@ def configuration(topology, request):
     configure_interface(sw1, SW1_INTF2, SW1_INTF2_IPV4_ADDR)
     configure_interface(sw2, SW2_INTF1, SW2_INTF1_IPV4_ADDR)
     configure_interface(sw3, SW3_INTF1, SW3_INTF1_IPV4_ADDR)
+
+    ports_sw1 = [sw1.ports[SW1_INTF1], sw1.ports[SW1_INTF2]]
+    verify_turn_on_interfaces(sw1, ports_sw1)
+    verify_turn_on_interfaces(sw2, [sw2.ports[SW2_INTF1]])
+    verify_turn_on_interfaces(sw3, [sw3.ports[SW3_INTF1]])
 
     # Configuring ospf with network command in sw1, sw2 and sw3
     configure_ospf_router(sw1, SW1_ROUTER_ID, SW1_INTF1_IPV4_ADDR, OSPF_AREA_1)

--- a/ops-tests/feature/ospf/test_ospfv2_ft_tmr_adjacency.py
+++ b/ops-tests/feature/ospf/test_ospfv2_ft_tmr_adjacency.py
@@ -20,7 +20,7 @@ from ospf_configs import configure_interface, configure_ospf_router
 from ospf_configs import wait_for_adjacency
 from ospf_configs import unconfigure_interface, unconfigure_ospf_router
 from pytest import fixture
-
+from interface_utils import verify_turn_on_interfaces
 
 TOPOLOGY = """
 # +-------+              +-------+              +------+
@@ -72,6 +72,11 @@ def configuration(topology, request):
     configure_interface(sw2, SW2_INTF1, SW2_INTF1_IPV4_ADDR)
     configure_interface(sw2, SW2_INTF2, SW2_INTF2_IPV4_ADDR)
     configure_interface(sw3, SW3_INTF1, SW3_INTF1_IPV4_ADDR)
+
+    verify_turn_on_interfaces(sw1, [sw1.ports[SW1_INTF1]])
+    ports_sw2 = [sw2.ports[SW2_INTF1], sw2.ports[SW2_INTF2]]
+    verify_turn_on_interfaces(sw2, ports_sw2)
+    verify_turn_on_interfaces(sw3, [sw3.ports[SW3_INTF1]])
 
     # Configuring ospf with network command in sw1, sw2 and sw3
     configure_ospf_router(sw1, SW1_ROUTER_ID, SW1_INTF1_IPV4_ADDR, OSPF_AREA_1)

--- a/ops-tests/feature/ospf/test_ospfv2_ft_virtual_links.py
+++ b/ops-tests/feature/ospf/test_ospfv2_ft_virtual_links.py
@@ -20,6 +20,7 @@ from ospf_configs import configure_interface, configure_ospf_router
 from ospf_configs import unconfigure_interface, unconfigure_ospf_router
 from ospf_configs import wait_for_adjacency, verify_virtual_links
 from pytest import fixture
+from interface_utils import verify_turn_on_interfaces
 
 TOPOLOGY = """
 #
@@ -81,6 +82,9 @@ def configuration(topology, request):
     configure_interface(dut1, DUT1_INTF2, DUT1_INTF2_IPV4_ADDR)
     configure_interface(sw1, SW1_INTF1, SW1_INTF1_IPV4_ADDR)
     configure_interface(sw3, SW3_INTF2, SW3_INTF2_IPV4_ADDR)
+
+    verify_turn_on_interfaces(sw1, [sw1.ports[SW1_INTF1]])
+    verify_turn_on_interfaces(sw3, [sw3.ports[SW3_INTF2]])
 
     # Configuring ospf with network command in dut1, sw1 and sw3
     configure_ospf_router(dut1, DUT1_ROUTER_ID, DUT1_INTF1_IPV4_ADDR,

--- a/ospfd/ospfd.c
+++ b/ospfd/ospfd.c
@@ -106,8 +106,6 @@ ospf_router_id_update (struct ospf *ospf)
     router_id = ospf->router_id_static;
   else if (ospf->router_id.s_addr != 0)
     router_id = ospf->router_id;
-  else
-    router_id = router_id_zebra;
 
   ospf->router_id = router_id;
 


### PR DESCRIPTION
Tags: fix, dev, Github issue #19

Change-Id: I70fff570e788dbc7025870c757a3a4baaa2e9f0d
Signed-off-by: Ilya Schepin ischepin@mera.ru

There are certain rules to assign OSPF (and BGP) router-ids automatically in case the user did not select the id manually. When id is assigned automatically, OSPF will pick it from zebra using zclient API (1st issue, according to OpenSwitch architecture there must be no interaction between components except interaction through OVSDB). OSPF will not write router-id retrieved from zebra to OSPF_Router table (2nd issue, CLI will print everyone except OSPF_Router:router_id as OSPF neighbor in `show ip ospf neighbor` command).  

Router-id should be obtained from OVSDB as BGP does it; using OVSDB table VRF, column active_router_id. Router-id should be written to OVSDB table OSPF_Router by OSPFD when assigned automatically.
