### PR TITLE
Loopback interface creation in ospf

### DIFF
--- a/ops-tests/component/ospf/test_ospfv2_ct_loopback_intf.py
+++ b/ops-tests/component/ospf/test_ospfv2_ct_loopback_intf.py
@@ -1,0 +1,58 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2015-2016 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from time import sleep
+
+TOPOLOGY = """
+#
+#
+# +-------+
+# +  sw1  +
+# +-------+
+#
+#
+
+# Nodes
+[type=openswitch name="Switch 1"] sw1
+
+"""
+
+def test_ospf_ct_loopback_intf(topology, step):
+    '''
+    This test verifies loopback interface configuration in ospfd
+    '''
+    ops1 = topology.get('sw1')
+
+    assert ops1 is not None
+
+    step('### Test to verify loopback interface configuration in ospfd ###')
+
+    ops1("config t")
+    ops1("interface loopback 1")
+    ops1("ip address 1.1.1.1/32")
+    ops1("exit")
+
+    ops1("router ospf")
+    ops1("router-id 1.1.1.1")
+    ops1("network 1.1.1.1/32 area 0")
+    ops1("exit")
+    ops1("exit")
+
+    sleep(5)
+
+    out = ops1("show ip ospf interface loopback1")
+    assert "loopback1" in out


### PR DESCRIPTION
During loopback interface configuration in ospf,
there could be a situation when the kernel
loopback interface is not ready/created yet by
ops-portd. In such a case, the interface hangs
in ops-ospfd with ifindex equal to 0. A special
handling added for that case: create loopback
interface during update event for the port entry.
The port entry (kernel_interface_ready field set
to true) is updated by ops-portd when loopback
interface is created in kernel.

Tags: dev, fix

Change-Id: If9919f308ead842572ebbade9b445b96215d904f
Signed-off-by: Nikolay Stroykov stroykov@mera.ru
