### PR TITLE
Default route LSA refresh

### DIFF
--- a/ospfd/ospf_zebra.c
+++ b/ospfd/ospf_zebra.c
@@ -50,6 +50,9 @@
 #endif /* HAVE_SNMP */
 
 #ifdef ENABLE_OVSDB
+extern unsigned char redist[ZEBRA_ROUTE_MAX];
+extern unsigned char redist_default;
+
 extern void
 if_set_value_from_ovsdb (struct ovsdb_idl *, const struct ovsrec_port *, struct interface *);
 #endif
@@ -775,8 +778,13 @@ ospf_zebra_delete_discard (struct prefix_ipv4 *p)
 int
 ospf_is_type_redistributed (int type)
 {
+#ifdef ENABLE_OVSDB
+  return (DEFAULT_ROUTE_TYPE (type)) ?
+    redist_default : redist[type];
+#else
   return (DEFAULT_ROUTE_TYPE (type)) ?
     zclient->default_information : zclient->redist[type];
+#endif
 }
 
 int


### PR DESCRIPTION
Fix LSA refresh for redistributed LSAs. After default route
configuration and setup as distributed, it is distributed as expected.
But after LSA refresh timer expires it is not refreshed and the
corresponding LSA is remove from LSADB. This problem relates to all
LSAs distributed as AS-External.

Tags: fix, dev, usr

Change-Id: I6d04d2c5da1cbf55707b53eed7a53042c06d55ba
Signed-off-by: Nikolay Stroykov stroykov@mera.ru
