### PR TITLE
Full notation IPv6 addresses

### DIFF
--- a/bgpd/bgp_ovsdb_if.c
+++ b/bgpd/bgp_ovsdb_if.c
@@ -1995,7 +1995,7 @@ get_bgp_neighbor_with_VrfName_BgpRouterAsn_Ipaddr (struct ovsdb_idl *idl,
             }
             ovs_bgp = ovs_vrf->value_bgp_routers[i];
             for (j = 0; j < ovs_bgp->n_bgp_neighbors; j++) {
-                if (0 == strcmp(ipaddr, ovs_bgp->key_bgp_neighbors[j])) {
+                if (ip_addr_is_equal(ipaddr, ovs_bgp->key_bgp_neighbors[j])) {
                     return ovs_bgp->value_bgp_neighbors[j];
                 }
             }

--- a/bgpd/bgp_ovsdb_route.c
+++ b/bgpd/bgp_ovsdb_route.c
@@ -398,7 +398,7 @@ bgp_ovsdb_lookup_nexthop(char *ip)
     OVSREC_NEXTHOP_FOR_EACH(row, idl) {
         if (row->ip_address)
         {
-            if (strcmp(ip, row->ip_address) == 0) {
+            if (ip_addr_is_equal(ip, row->ip_address)) {
                 /* Match */
                 return row;
             }
@@ -417,7 +417,7 @@ bgp_ovsdb_lookup_local_nexthop(char *ip)
     OVSREC_BGP_NEXTHOP_FOR_EACH(row, idl) {
         if (row->ip_address)
         {
-            if (strcmp(ip, row->ip_address) == 0) {
+            if (ip_addr_is_equal(ip, row->ip_address)) {
                 /* Match */
                 return row;
             }

--- a/lib/prefix.c
+++ b/lib/prefix.c
@@ -903,4 +903,26 @@ inet6_ntoa (struct in6_addr addr)
   inet_ntop (AF_INET6, &addr, buf, INET6_ADDRSTRLEN);
   return buf;
 }
+
+int
+ip_addr_is_equal (const char *addr_str1, const char *addr_str2) {
+  int af;
+
+  af = ((strstr(addr_str1, ":") != NULL) ? AF_INET6 : AF_INET);
+  return ip_addr_is_equal_af(af, addr_str1, addr_str2);
+}
+
+int
+ip_addr_is_equal_af (int af, const char *addr_str1, const char *addr_str2) {
+  struct in6_addr addr1, addr2;
+
+  if (af == AF_INET) {
+    return !strcmp(addr_str1, addr_str2);
+  }
+  else if (inet_pton(AF_INET6, addr_str1, &addr1) && inet_pton(AF_INET6, addr_str2, &addr2)) {
+    return !IPV6_ADDR_CMP(&addr1, &addr2);
+  }
+  return 0;
+}
+
 #endif /* HAVE_IPV6 */

--- a/lib/prefix.h
+++ b/lib/prefix.h
@@ -219,6 +219,8 @@ extern void masklen2ip6 (const int, struct in6_addr *);
 
 extern void str2in6_addr (const char *, struct in6_addr *);
 extern const char *inet6_ntoa (struct in6_addr);
+extern int ip_addr_is_equal (const char *, const char *);
+extern int ip_addr_is_equal_af (int, const char *, const char *);
 
 #endif /* HAVE_IPV6 */
 

--- a/zebra/zebra_ovsdb_if.c
+++ b/zebra/zebra_ovsdb_if.c
@@ -536,7 +536,7 @@ zebra_if_cached_port_and_ovsrec_port_ip6_addr_change (
    * If the OVSDB port primary address and L3 port primary address
    * are not same, then return 'true'.
    */
-  if (strcmp(port->ip6_address, l3_port->ip6_address) != 0)
+  if (ip_addr_is_equal_af(AF_INET6, port->ip6_address, l3_port->ip6_address))
     return(true);
 
   /*
@@ -1508,7 +1508,7 @@ zebra_reconfigure_primary_addresses (
                                                is_v4,
                                                l3_port);
         }
-      else if (strcmp(ovsrec_port_primary_address, *l3_port_primary_address))
+      else if (ip_addr_is_equal_af(is_v4 ? AF_INET : AF_INET6, ovsrec_port_primary_address, *l3_port_primary_address))
         {
           /*
            * If the L3 port node primary address is not same as the OVSDB
@@ -5756,7 +5756,7 @@ void zebra_delete_route_nexthop_addr_from_db (struct rib *route,
            * Check if the nexthop_str is same as the next-hop IP
            * address.
            */
-          if (strcmp(nexthop_str, nh_row->ip_address) == 0)
+          if (ip_addr_is_equal(nexthop_str, nh_row->ip_address))
             {
               VLOG_DBG("Found the nexthop match");
               found_nexthop_addr[next_hop_index] = true;
@@ -6153,7 +6153,7 @@ void zebra_update_selected_nh (struct route_node *rn, struct rib *route,
            */
           if (nh_addr && nh_row->ip_address)
             {
-              if (strcmp(nh_row->ip_address, nh_addr) == 0)
+              if (ip_addr_is_equal(nh_row->ip_address, nh_addr))
                 {
                   VLOG_DBG("Found a match with the nh address %s",
                             nh_row->ip_address);


### PR DESCRIPTION
In Quagga function strcmp is used to compare both ipv4 and ipv6 addresses.
This is incorrect, since there are multiple string representations of one
ipv6 address (e.g. strings 2002::a1, 2002:0:0:0:0:0:0:a1, 2002::00a1,
2002::00A1 represent one ipv6 address, 2002:0000:0000:0000:0000:0000:0000:00a1.
Possible representations are described in RFC 5952). To correctly compare
ipv6 addresses, they must be compared using IPV6_ADDR_CMP function (defined
in lib/prefix.h), which will compare addresses stored in struct in6_addr form.

In some cases calling function is not aware of underlying string address
family (AF_INET or AF_INET6). So wrapping function ip_addr_is_equal is created,
to determine AF of IP address string.

Tags: fix, dev, chg

Change-Id: I9a11038b0ac50613601d1ca56ce97388fbb84dbb
Signed-off-by: Ilya Schepin ischepin@mera.ru
