### PR TITLE
Fix for OSPFv2: Kernel IP routing table misses gateways

### DIFF
--- a/ospfd/ospf_ovsdb_if.c
+++ b/ospfd/ospf_ovsdb_if.c
@@ -3330,7 +3330,7 @@ ovsdb_ospf_add_route_nexthops (const struct ovsdb_idl_txn *txn,
             len_str = strlen( temp_str);
             ovsrec_nexthop_set_ip_address(pnexthop, nexthop_buf);
         }
-        if (path->ifindex != 0)
+        else if (path->ifindex != 0)
         {
             ifname = ifindex2ifname(path->ifindex);
             if (ifname)


### PR DESCRIPTION
In case of IP nexthop, ospfd now avoids to configure
'ports' column in the OVSDB table Nexthop.
And while configuring kernel routes zebra correctly
determines nexthop type: ip or port.

Tags: fix, dev
TG-1978

Change-Id: I27b0cab392b4cb004cad0932d65cab78ba008d8c
