### PR TITLE
Automatic OSPF router-id assignment

### DIFF
--- a/ops-tests/component/ospf/test_ospfv2_ct_verify_config.py
+++ b/ops-tests/component/ospf/test_ospfv2_ct_verify_config.py
@@ -1,0 +1,58 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2015-2016 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from time import sleep
+
+TOPOLOGY = """
+#
+#
+# +-------+
+# +  sw1  +
+# +-------+
+#
+#
+
+# Nodes
+[type=openswitch name="Switch 1"] sw1
+
+"""
+
+def test_ospf_ct_verify_router_id(topology, step):
+    sw = topology.get('sw1')
+    ospf_auto_router_id = "192.168.1.1"
+    ospf_man_router_id = "1.1.1.1"
+    lo2_addr = "172.16.1.1"
+    assert sw is not None
+
+    step('### Test to verify correct OSPF router-id assignment ###')
+    step('### 1. Test that router-id is assigned automatically from VRF table ###')
+    sw("configure terminal")
+    sw("interface loopback 1")
+    sw("ip address %s/32" % ospf_auto_router_id)
+    sw("exit")
+    sw("configure terminal")
+    sw("interface loopback 2")
+    sw("ip address %s/32" % lo2_addr)
+    sw("exit")
+    sw("router ospf")
+    ospf_cfg = sw("do show ip ospf")
+    assert "Router ID:  %s" % ospf_auto_router_id in ospf_cfg
+    step('### 2. Test that manually set router-id overrides automatically assigned ###')
+    sw("router-id %s" % ospf_man_router_id)
+    ospf_cfg = sw("do show ip ospf")
+    assert "Router ID:  %s" % ospf_man_router_id in ospf_cfg
+    step('### Router-id is correct, test passed ###')

--- a/ospfd/ospfd.c
+++ b/ospfd/ospfd.c
@@ -106,8 +106,6 @@ ospf_router_id_update (struct ospf *ospf)
     router_id = ospf->router_id_static;
   else if (ospf->router_id.s_addr != 0)
     router_id = ospf->router_id;
-  else
-    router_id = router_id_zebra;
 
   ospf->router_id = router_id;
 


### PR DESCRIPTION
There are certain rules to assign OSPF (and BGP) router-ids
automatically in case the user did not select the id manually.
When id is assigned automatically, OSPF will pick it from
zebra using zclient API (1st issue, according to OpenSwitch
architecture there must be no interaction between components
except interaction through OVSDB). OSPF will not write
router-id retrieved from zebra to OSPF_Router table (2nd
issue, CLI will print everyone except OSPF_Router:router_id
as OSPF neighbor in show ip ospf neighbor command.
Router-id should be obtained from OVSDB as BGP does it;
using OVSDB table VRF, column active_router_id. Router-id
should be written to OVSDB table OSPF_Router by OSPFD when
assigned automatically.

Tags: fix, dev

Change-Id: I70fff570e788dbc7025870c757a3a4baaa2e9f0d
Signed-off-by: Ilya Schepin ischepin@mera.ru
